### PR TITLE
Add Coordinator, disable incompatible modes for FAN and TEMP

### DIFF
--- a/custom_components/airzoneclouddaikin/__init__.py
+++ b/custom_components/airzoneclouddaikin/__init__.py
@@ -47,17 +47,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.error("Login to Airzone API failed.")
         return False
 
-    # Create a DataUpdateCoordinator to poll API data every scan_interval seconds. 
-    scan_interval = config.get("scan_interval", 30)
-    if scan_interval < 10:
-        scan_interval = 10
-
+    # Hard-code update interval to 10 seconds.
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
         name="airzone_data",
         update_method=lambda: _async_update_data(api),
-        update_interval=timedelta(seconds=scan_interval),
+        update_interval=timedelta(seconds=10),
     )
     # Attach the API instance to the coordinator so that entities can use it.
     coordinator.api = api

--- a/custom_components/airzoneclouddaikin/__init__.py
+++ b/custom_components/airzoneclouddaikin/__init__.py
@@ -1,16 +1,65 @@
 """DKN Cloud for HASS integration."""
 import logging
+from datetime import timedelta
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-DOMAIN = "airzoneclouddaikin"
+from .const import DOMAIN
+from .airzone_api import AirzoneAPI
 
 _LOGGER = logging.getLogger(__name__)
+
+async def _async_update_data(api: AirzoneAPI) -> dict:
+    """Fetch and aggregate device data from the API.
+
+    This function fetches installations and then, for each installation,
+    fetches all devices. The data is aggregated into a dictionary keyed by device id.
+    """
+    data = {}
+    installations = await api.fetch_installations()
+    for relation in installations:
+        installation = relation.get("installation")
+        if not installation:
+            continue
+        installation_id = installation.get("id")
+        if not installation_id:
+            continue
+        devices = await api.fetch_devices(installation_id)
+        for device in devices:
+            data[device["id"]] = device
+    return data
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up DKN Cloud for HASS from a config entry."""
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = entry.data
+    config = entry.data
+
+    from homeassistant.helpers.aiohttp_client import async_get_clientsession
+    session = async_get_clientsession(hass)
+    api = AirzoneAPI(config.get("username"), config.get("password"), session)
+    if not await api.login():
+        _LOGGER.error("Login to Airzone API failed.")
+        return False
+
+    # Create a DataUpdateCoordinator to poll API data every scan_interval seconds.
+    scan_interval = config.get("scan_interval", 30)
+    if scan_interval < 10:
+        scan_interval = 10
+    coordinator = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name="airzone_data",
+        update_method=lambda: _async_update_data(api),
+        update_interval=timedelta(seconds=scan_interval),
+    )
+    try:
+        await coordinator.async_config_entry_first_refresh()
+    except Exception as err:
+        _LOGGER.error("Failed to fetch initial data: %s", err)
+        raise UpdateFailed(err) from err
+
+    hass.data[DOMAIN][entry.entry_id] = {"api": api, "coordinator": coordinator}
     # Forward setups for climate, sensor, and switch platforms.
     await hass.config_entries.async_forward_entry_setups(entry, ["climate", "sensor", "switch"])
     _LOGGER.info("DKN Cloud for HASS integration configured successfully.")

--- a/custom_components/airzoneclouddaikin/__init__.py
+++ b/custom_components/airzoneclouddaikin/__init__.py
@@ -29,7 +29,7 @@ async def _async_update_data(api: AirzoneAPI) -> dict:
         for device in devices:
             device_id = device.get("id")
             if not device_id:
-                # Fallback: use a hash of the device data if no id is provided.
+                # Fallback: use a hash of the device data if no id is provided
                 device_id = f"{hash(str(device))}"
                 device["id"] = device_id
             data[device_id] = device

--- a/custom_components/airzoneclouddaikin/__init__.py
+++ b/custom_components/airzoneclouddaikin/__init__.py
@@ -1,6 +1,9 @@
 """DKN Cloud for HASS integration."""
+import json
+import hashlib
 import logging
 from datetime import timedelta
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -13,8 +16,10 @@ _LOGGER = logging.getLogger(__name__)
 async def _async_update_data(api: AirzoneAPI) -> dict:
     """Fetch and aggregate device data from the API.
 
-    This function fetches installations and then, for each installation,
-    fetches all devices. The data is aggregated into a dictionary keyed by device id.
+    This function retrieves installations and, for each installation,
+    fetches all devices. It generates a stable device id (if missing) 
+    based on static fields ('name' and 'mac') and returns a dictionary
+    keyed by these unique IDs.
     """
     data = {}
     installations = await api.fetch_installations()
@@ -28,10 +33,14 @@ async def _async_update_data(api: AirzoneAPI) -> dict:
         devices = await api.fetch_devices(installation_id)
         for device in devices:
             device_id = device.get("id")
-            if not device_id:
-                # Fallback: use a hash of the device data if no id is provided
-                device_id = f"{hash(str(device))}"
-                device["id"] = device_id
+            if not device_id or not str(device_id).strip():
+                # Generate a stable id based on static fields
+                static_fields = {
+                    "name": device.get("name", ""),
+                    "mac": device.get("mac", "")
+                }
+                device_id = hashlib.sha256(json.dumps(static_fields, sort_keys=True).encode("utf-8")).hexdigest()
+                device["id"] = device_id  # Update the device data for future use
             data[device_id] = device
     return data
 
@@ -47,15 +56,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.error("Login to Airzone API failed.")
         return False
 
-    # Hard-code update interval to 10 seconds.
+    # Set update interval to 10 seconds (or use the configured interval, ensuring a minimum of 10)
+    scan_interval = config.get("scan_interval", 10)
+    if scan_interval < 10:
+        scan_interval = 10
+
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
         name="airzone_data",
         update_method=lambda: _async_update_data(api),
-        update_interval=timedelta(seconds=10),
+        update_interval=timedelta(seconds=scan_interval),
     )
-    # Attach the API instance to the coordinator so that entities can use it.
+    # Attach the API instance to the coordinator for use by entities.
     coordinator.api = api
 
     try:
@@ -65,7 +78,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise UpdateFailed(err) from err
 
     hass.data[DOMAIN][entry.entry_id] = {"api": api, "coordinator": coordinator}
-    # Forward setups for climate, sensor, and switch platforms.
+    # Forward the entry to set up the climate, sensor, and switch platforms.
     await hass.config_entries.async_forward_entry_setups(entry, ["climate", "sensor", "switch"])
     _LOGGER.info("DKN Cloud for HASS integration configured successfully.")
     return True

--- a/custom_components/airzoneclouddaikin/__init__.py
+++ b/custom_components/airzoneclouddaikin/__init__.py
@@ -29,7 +29,7 @@ async def _async_update_data(api: AirzoneAPI) -> dict:
         for device in devices:
             device_id = device.get("id")
             if not device_id:
-                # Fallback: use hash of the device data
+                # Fallback: use a hash of the device data if no id is provided
                 device_id = f"{hash(str(device))}"
                 device["id"] = device_id
             data[device_id] = device
@@ -59,6 +59,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         update_method=lambda: _async_update_data(api),
         update_interval=timedelta(seconds=scan_interval),
     )
+    # Attach the API instance to the coordinator so that entities can use it.
+    coordinator.api = api
+
     try:
         await coordinator.async_config_entry_first_refresh()
     except Exception as err:

--- a/custom_components/airzoneclouddaikin/airzone_api.py
+++ b/custom_components/airzoneclouddaikin/airzone_api.py
@@ -34,10 +34,7 @@ class AirzoneAPI:
         """
         url = f"{BASE_URL}{API_LOGIN}"
         payload = {"email": self._username, "password": self._password}
-        headers = {
-            "User-Agent": USER_AGENT,
-            "Content-Type": "application/json"
-        }
+        headers = {"User-Agent": USER_AGENT, "Content-Type": "application/json"}
         try:
             async with self._session.post(url, json=payload, headers=headers) as response:
                 if response.status == 201:

--- a/custom_components/airzoneclouddaikin/climate.py
+++ b/custom_components/airzoneclouddaikin/climate.py
@@ -1,80 +1,272 @@
-"""DKN Cloud for HASS integration."""
+"""Climate platform for DKN Cloud for HASS using the Airzone Cloud API with DataUpdateCoordinator."""
+import asyncio
 import logging
-from datetime import timedelta
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-
+from homeassistant.components.climate import ClimateEntity
+from homeassistant.components.climate.const import ClimateEntityFeature, HVACMode
+from homeassistant.const import UnitOfTemperature, ATTR_TEMPERATURE
 from .const import DOMAIN
-from .airzone_api import AirzoneAPI
 
 _LOGGER = logging.getLogger(__name__)
 
-async def _async_update_data(api: AirzoneAPI) -> dict:
-    """Fetch and aggregate device data from the API.
-
-    This function fetches installations and then, for each installation,
-    fetches all devices. The data is aggregated into a dictionary keyed by device id.
-    """
-    data = {}
-    installations = await api.fetch_installations()
-    for relation in installations:
-        installation = relation.get("installation")
-        if not installation:
-            continue
-        installation_id = installation.get("id")
-        if not installation_id:
-            continue
-        devices = await api.fetch_devices(installation_id)
-        for device in devices:
-            device_id = device.get("id")
-            if not device_id:
-                # Fallback: use a hash of the device data if no id is provided.
-                device_id = f"{hash(str(device))}"
-                device["id"] = device_id
-            data[device_id] = device
-    return data
-
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up DKN Cloud for HASS from a config entry."""
-    hass.data.setdefault(DOMAIN, {})
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up the climate platform from a config entry using the DataUpdateCoordinator."""
+    data = hass.data[DOMAIN].get(entry.entry_id)
+    if not data:
+        _LOGGER.error("No data found in hass.data for entry %s", entry.entry_id)
+        return
+    coordinator = data.get("coordinator")
+    api = data.get("api")
     config = entry.data
+    entities = []
+    # Create a climate entity for each device in the coordinator data.
+    for device_id, device in coordinator.data.items():
+        entities.append(AirzoneClimate(coordinator, api, device, config, hass))
+    async_add_entities(entities, True)
 
-    from homeassistant.helpers.aiohttp_client import async_get_clientsession
-    session = async_get_clientsession(hass)
-    api = AirzoneAPI(config.get("username"), config.get("password"), session)
-    if not await api.login():
-        _LOGGER.error("Login to Airzone API failed.")
-        return False
+class AirzoneClimate(ClimateEntity):
+    """Representation of an Airzone Cloud Daikin climate device."""
 
-    # Hard-code update interval to 10 seconds.
-    coordinator = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        name="airzone_data",
-        update_method=lambda: _async_update_data(api),
-        update_interval=timedelta(seconds=10),
-    )
-    # Attach the API instance to the coordinator so that entities can use it.
-    coordinator.api = api
+    def __init__(self, coordinator, api, device_data: dict, config: dict, hass):
+        """Initialize the climate entity.
 
-    try:
-        await coordinator.async_config_entry_first_refresh()
-    except Exception as err:
-        _LOGGER.error("Failed to fetch initial data: %s", err)
-        raise UpdateFailed(err) from err
+        :param coordinator: The DataUpdateCoordinator instance.
+        :param api: The AirzoneAPI instance.
+        :param device_data: Dictionary with device information.
+        :param config: Integration configuration.
+        :param hass: Home Assistant instance.
+        """
+        self.coordinator = coordinator
+        self._api = api
+        self._device_data = device_data  # We assume this includes a valid "id"
+        self._config = config
+        self.hass = hass
+        self._attr_name = device_data.get("name", "Airzone Device")
+        self._attr_unique_id = device_data.get("id")
+        self._attr_temperature_unit = UnitOfTemperature.CELSIUS
 
-    hass.data[DOMAIN][entry.entry_id] = {"api": api, "coordinator": coordinator}
-    # Forward setups for climate, sensor, and switch platforms.
-    await hass.config_entries.async_forward_entry_setups(entry, ["climate", "sensor", "switch"])
-    _LOGGER.info("DKN Cloud for HASS integration configured successfully.")
-    return True
+        # Initialize dynamic properties
+        self._hvac_mode = HVACMode.OFF
+        self._target_temperature = None
+        self._fan_mode = None
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_forward_entry_unload(entry, "climate")
-    unload_ok = unload_ok and await hass.config_entries.async_forward_entry_unload(entry, "sensor")
-    unload_ok = unload_ok and await hass.config_entries.async_forward_entry_unload(entry, "switch")
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-    return unload_ok
+    @property
+    def hvac_modes(self):
+        """Return the list of supported HVAC modes."""
+        modes = [HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT, HVACMode.FAN_ONLY, HVACMode.DRY]
+        if self._config.get("force_hvac_mode_auto", False):
+            modes.append(HVACMode.AUTO)
+        return modes
+
+    @property
+    def hvac_mode(self):
+        """Return the current HVAC mode."""
+        return self._hvac_mode
+
+    @property
+    def target_temperature(self):
+        """Return the current target temperature.
+
+        Temperature control is disabled in OFF, DRY and FAN_ONLY modes.
+        """
+        if self._hvac_mode in [HVACMode.OFF, HVACMode.DRY, HVACMode.FAN_ONLY]:
+            return None
+        return self._target_temperature
+
+    @property
+    def supported_features(self):
+        """Return supported features based on current mode.
+
+        - In OFF and DRY modes: no temperature or fan control.
+        - In FAN_ONLY mode: only fan control.
+        - Otherwise: both target temperature and fan control are supported.
+        """
+        if self._hvac_mode in [HVACMode.OFF, HVACMode.DRY]:
+            return 0
+        elif self._hvac_mode == HVACMode.FAN_ONLY:
+            return ClimateEntityFeature.FAN_MODE
+        else:
+            return ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
+
+    @property
+    def fan_modes(self):
+        """Return a list of valid fan speeds as strings based on 'availables_speeds'."""
+        # Fan controls should only be available if the mode is not OFF or DRY.
+        if self._hvac_mode in [HVACMode.OFF, HVACMode.DRY]:
+            return []
+        speeds = self.fan_speed_range
+        return [str(speed) for speed in speeds]
+
+    @property
+    def fan_mode(self):
+        """Return the current fan speed.
+
+        Returns None if the mode is OFF or DRY.
+        """
+        if self._hvac_mode in [HVACMode.OFF, HVACMode.DRY]:
+            return None
+        return self._fan_mode
+
+    @property
+    def device_info(self):
+        """Return device info to group this entity with others in the device registry."""
+        return {
+            "identifiers": {(DOMAIN, self._device_data.get("id"))},
+            "name": self._device_data.get("name"),
+            "manufacturer": "Daikin",
+            "model": self._device_data.get("brand", "Unknown"),
+            "sw_version": self._device_data.get("firmware", "Unknown"),
+            "via_device": (DOMAIN, self._device_data.get("id")),
+        }
+
+    async def async_update(self):
+        """Update the climate entity from the coordinator data."""
+        await self.coordinator.async_request_refresh()
+        # Use the device id as key to fetch updated data from the coordinator.
+        device = self.coordinator.data.get(self._device_data.get("id"))
+        if device:
+            self._device_data = device
+            if int(device.get("power", 0)) == 1:
+                mode_val = device.get("mode")
+                if mode_val == "1":
+                    self._hvac_mode = HVACMode.COOL
+                    self._target_temperature = int(float(device.get("cold_consign", "0")))
+                    self._fan_mode = str(device.get("cold_speed", ""))
+                elif mode_val == "2":
+                    self._hvac_mode = HVACMode.HEAT
+                    self._target_temperature = int(float(device.get("heat_consign", "0")))
+                    self._fan_mode = str(device.get("heat_speed", ""))
+                elif mode_val == "3":
+                    self._hvac_mode = HVACMode.FAN_ONLY
+                    self._target_temperature = None
+                    self._fan_mode = str(device.get("cold_speed", ""))
+                elif mode_val == "5":
+                    self._hvac_mode = HVACMode.DRY
+                    self._target_temperature = None
+                    self._fan_mode = None
+                elif mode_val == "4":
+                    self._hvac_mode = HVACMode.AUTO
+                    self._target_temperature = int(float(device.get("heat_consign", "0")))
+                    self._fan_mode = str(device.get("heat_speed", ""))
+                else:
+                    self._hvac_mode = HVACMode.HEAT
+                    self._target_temperature = int(float(device.get("heat_consign", "0")))
+                    self._fan_mode = str(device.get("heat_speed", ""))
+            else:
+                self._hvac_mode = HVACMode.OFF
+                self._target_temperature = None
+                self._fan_mode = None
+        self.async_write_ha_state()
+
+    async def async_set_hvac_mode(self, hvac_mode):
+        """Set the HVAC mode asynchronously."""
+        if hvac_mode == HVACMode.OFF:
+            self._hvac_mode = HVACMode.OFF
+            self._target_temperature = None
+            self._fan_mode = None
+            self._send_command("P1", 0)
+        else:
+            if self._hvac_mode == HVACMode.OFF:
+                self._send_command("P1", 1)
+                # Let the coordinator update the state in the next refresh.
+            mode_mapping = {
+                HVACMode.COOL: "1",
+                HVACMode.HEAT: "2",
+                HVACMode.FAN_ONLY: "3",
+                HVACMode.DRY: "5",
+                HVACMode.AUTO: "4",
+            }
+            if hvac_mode in mode_mapping:
+                self._send_command("P2", mode_mapping[hvac_mode])
+                self._hvac_mode = hvac_mode
+            else:
+                _LOGGER.error("Unsupported HVAC mode: %s", hvac_mode)
+        self.async_write_ha_state()
+
+    async def async_set_temperature(self, **kwargs):
+        """Set the target temperature asynchronously.
+
+        This action is allowed only in modes that support temperature control.
+        """
+        if self._hvac_mode in [HVACMode.OFF, HVACMode.DRY, HVACMode.FAN_ONLY]:
+            _LOGGER.warning("Temperature adjustment not supported in mode %s", self._hvac_mode)
+            return
+        temp = kwargs.get(ATTR_TEMPERATURE)
+        if temp is not None:
+            temp = int(float(temp))
+            if self._hvac_mode in [HVACMode.HEAT, HVACMode.AUTO]:
+                min_temp = int(float(self._device_data.get("min_limit_heat", 16)))
+                max_temp = int(float(self._device_data.get("max_limit_heat", 32)))
+                command = "P8"
+            else:
+                min_temp = int(float(self._device_data.get("min_limit_cold", 16)))
+                max_temp = int(float(self._device_data.get("max_limit_cold", 32)))
+                command = "P7"
+            if temp < min_temp:
+                temp = min_temp
+            elif temp > max_temp:
+                temp = max_temp
+            self._send_command(command, f"{temp}.0")
+            self._target_temperature = temp
+            self.async_write_ha_state()
+
+    async def async_set_fan_mode(self, fan_mode):
+        """Set the fan mode asynchronously."""
+        if self._hvac_mode in [HVACMode.OFF, HVACMode.DRY]:
+            _LOGGER.warning("Fan control not supported in mode %s", self._hvac_mode)
+            return
+        await self.hass.async_add_executor_job(self.set_fan_mode, fan_mode)
+        self.async_write_ha_state()
+
+    def set_fan_mode(self, fan_mode):
+        """Set the fan mode by calling set_fan_speed."""
+        self.set_fan_speed(fan_mode)
+
+    def set_fan_speed(self, speed):
+        """Set the fan speed.
+
+        Uses P3 in COOL and FAN_ONLY modes and P4 in HEAT/AUTO modes.
+        Fan control is not available in OFF or DRY modes.
+        """
+        try:
+            speed = int(speed)
+        except ValueError:
+            _LOGGER.error("Invalid fan speed: %s", speed)
+            return
+        if speed not in self.fan_speed_range:
+            _LOGGER.error("Fan speed %s not in valid range %s", speed, self.fan_speed_range)
+            return
+        if self._hvac_mode in [HVACMode.COOL, HVACMode.FAN_ONLY]:
+            self._send_command("P3", speed)
+        elif self._hvac_mode in [HVACMode.HEAT, HVACMode.AUTO]:
+            self._send_command("P4", speed)
+        else:
+            _LOGGER.warning("Fan speed adjustment not supported in mode %s", self._hvac_mode)
+            return
+        self._fan_mode = str(speed)
+        self.async_write_ha_state()
+
+    @property
+    def fan_speed_range(self):
+        """Return a list of valid fan speeds based on 'availables_speeds' from device data."""
+        speeds_str = self._device_data.get("availables_speeds", "3")
+        try:
+            speeds = int(speeds_str)
+        except ValueError:
+            speeds = 3
+        return list(range(1, speeds + 1))
+
+    def _send_command(self, option, value):
+        """Send a command to the device using the events endpoint."""
+        payload = {
+            "event": {
+                "cgi": "modmaquina",
+                "device_id": self._device_data.get("id"),
+                "option": option,
+                "value": value,
+            }
+        }
+        _LOGGER.info("Sending command: %s", payload)
+        if self.hass and self.hass.loop:
+            asyncio.run_coroutine_threadsafe(self._api.send_event(payload), self.hass.loop)
+        else:
+            _LOGGER.error("No hass loop available; cannot send command.")

--- a/custom_components/airzoneclouddaikin/climate.py
+++ b/custom_components/airzoneclouddaikin/climate.py
@@ -1,84 +1,268 @@
-"""DKN Cloud for HASS integration."""
+"""Climate platform for DKN Cloud for HASS using the Airzone Cloud API with DataUpdateCoordinator."""
+import asyncio
 import logging
-from datetime import timedelta
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-
+from homeassistant.components.climate import ClimateEntity
+from homeassistant.components.climate.const import ClimateEntityFeature, HVACMode
+from homeassistant.const import UnitOfTemperature, ATTR_TEMPERATURE
 from .const import DOMAIN
-from .airzone_api import AirzoneAPI
 
 _LOGGER = logging.getLogger(__name__)
 
-async def _async_update_data(api: AirzoneAPI) -> dict:
-    """Fetch and aggregate device data from the API.
-
-    This function fetches installations and then, for each installation,
-    fetches all devices. The data is aggregated into a dictionary keyed by device id.
-    """
-    data = {}
-    installations = await api.fetch_installations()
-    for relation in installations:
-        installation = relation.get("installation")
-        if not installation:
-            continue
-        installation_id = installation.get("id")
-        if not installation_id:
-            continue
-        devices = await api.fetch_devices(installation_id)
-        for device in devices:
-            device_id = device.get("id")
-            if not device_id:
-                # Fallback: use a hash of the device data if no id is provided
-                device_id = f"{hash(str(device))}"
-                device["id"] = device_id
-            data[device_id] = device
-    return data
-
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up DKN Cloud for HASS from a config entry."""
-    hass.data.setdefault(DOMAIN, {})
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up the climate platform from a config entry using the DataUpdateCoordinator."""
+    data = hass.data[DOMAIN].get(entry.entry_id)
+    if not data:
+        _LOGGER.error("No data found in hass.data for entry %s", entry.entry_id)
+        return
+    coordinator = data.get("coordinator")
+    api = data.get("api")
     config = entry.data
+    entities = []
+    # Create a climate entity for each device in the coordinator data.
+    for device_id, device in coordinator.data.items():
+        entities.append(AirzoneClimate(coordinator, api, device, config, hass))
+    async_add_entities(entities, True)
 
-    from homeassistant.helpers.aiohttp_client import async_get_clientsession
-    session = async_get_clientsession(hass)
-    api = AirzoneAPI(config.get("username"), config.get("password"), session)
-    if not await api.login():
-        _LOGGER.error("Login to Airzone API failed.")
-        return False
+class AirzoneClimate(ClimateEntity):
+    """Representation of an Airzone Cloud Daikin climate device."""
 
-    # Use a default scan interval of 10 seconds (minimum 10 seconds)
-    scan_interval = config.get("scan_interval", 10)
-    if scan_interval < 10:
-        scan_interval = 10
+    def __init__(self, coordinator, api, device_data: dict, config: dict, hass):
+        """Initialize the climate entity.
 
-    coordinator = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        name="airzone_data",
-        update_method=lambda: _async_update_data(api),
-        update_interval=timedelta(seconds=scan_interval),
-    )
-    # Attach the API instance to the coordinator so that entities can use it.
-    coordinator.api = api
+        :param coordinator: The DataUpdateCoordinator instance.
+        :param api: The AirzoneAPI instance.
+        :param device_data: Dictionary with device information.
+        :param config: Integration configuration.
+        :param hass: Home Assistant instance.
+        """
+        self.coordinator = coordinator
+        self._api = api
+        self._device_data = device_data
+        self._config = config
+        self.hass = hass
+        self._attr_name = device_data.get("name", "Airzone Device")
+        # Use the device's id as unique_id; it is assumed to be present.
+        self._attr_unique_id = device_data.get("id")
+        self._attr_temperature_unit = UnitOfTemperature.CELSIUS
+        self._hvac_mode = HVACMode.OFF
+        self._target_temperature = None
+        self._fan_mode = None
 
-    try:
-        await coordinator.async_config_entry_first_refresh()
-    except Exception as err:
-        _LOGGER.error("Failed to fetch initial data: %s", err)
-        raise UpdateFailed(err) from err
+    @property
+    def hvac_modes(self):
+        """Return the list of supported HVAC modes."""
+        modes = [HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT, HVACMode.FAN_ONLY, HVACMode.DRY]
+        if self._config.get("force_hvac_mode_auto", False):
+            modes.append(HVACMode.AUTO)
+        return modes
 
-    hass.data[DOMAIN][entry.entry_id] = {"api": api, "coordinator": coordinator}
-    # Forward setups for climate, sensor, and switch platforms.
-    await hass.config_entries.async_forward_entry_setups(entry, ["climate", "sensor", "switch"])
-    _LOGGER.info("DKN Cloud for HASS integration configured successfully.")
-    return True
+    @property
+    def hvac_mode(self):
+        """Return the current HVAC mode."""
+        return self._hvac_mode
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_forward_entry_unload(entry, "climate")
-    unload_ok = unload_ok and await hass.config_entries.async_forward_entry_unload(entry, "sensor")
-    unload_ok = unload_ok and await hass.config_entries.async_forward_entry_unload(entry, "switch")
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-    return unload_ok
+    @property
+    def target_temperature(self):
+        """Return the current target temperature."""
+        return self._target_temperature
+
+    @property
+    def supported_features(self):
+        """Return supported features: target temperature and fan mode."""
+        return ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
+
+    @property
+    def fan_modes(self):
+        """Return a list of valid fan speeds as strings based on 'availables_speeds'."""
+        speeds = self.fan_speed_range
+        return [str(speed) for speed in speeds]
+
+    @property
+    def fan_mode(self):
+        """Return the current fan speed."""
+        return self._fan_mode
+
+    @property
+    def device_info(self):
+        """Return device info to group this entity with others in the device registry."""
+        return {
+            "identifiers": {(DOMAIN, self._device_data.get("id"))},
+            "name": self._device_data.get("name"),
+            "manufacturer": "Daikin",
+            "model": self._device_data.get("brand", "Unknown"),
+            "sw_version": self._device_data.get("firmware", "Unknown"),
+            "via_device": (DOMAIN, self._device_data.get("id")),
+        }
+
+    async def async_update(self):
+        """Update the climate entity from the coordinator data."""
+        await self.coordinator.async_request_refresh()
+        device = self.coordinator.data.get(self._device_data.get("id"))
+        if device:
+            self._device_data = device
+            if int(device.get("power", 0)) == 1:
+                mode_val = device.get("mode")
+                if mode_val == "1":
+                    self._hvac_mode = HVACMode.COOL
+                    self._target_temperature = int(float(device.get("cold_consign", "0")))
+                    self._fan_mode = str(device.get("cold_speed", ""))
+                elif mode_val == "2":
+                    self._hvac_mode = HVACMode.HEAT
+                    self._target_temperature = int(float(device.get("heat_consign", "0")))
+                    self._fan_mode = str(device.get("heat_speed", ""))
+                elif mode_val == "3":
+                    self._hvac_mode = HVACMode.FAN_ONLY
+                    self._fan_mode = str(device.get("cold_speed", ""))
+                elif mode_val == "5":
+                    self._hvac_mode = HVACMode.DRY
+                    self._fan_mode = ""
+                elif mode_val == "4":
+                    self._hvac_mode = HVACMode.AUTO
+                    self._target_temperature = int(float(device.get("heat_consign", "0")))
+                    self._fan_mode = str(device.get("heat_speed", ""))
+                else:
+                    self._hvac_mode = HVACMode.HEAT
+                    self._target_temperature = int(float(device.get("heat_consign", "0")))
+                    self._fan_mode = str(device.get("heat_speed", ""))
+            else:
+                self._hvac_mode = HVACMode.OFF
+        # No direct state write; state will update via coordinator refresh
+
+    async def async_set_fan_mode(self, fan_mode):
+        """Set the fan mode asynchronously."""
+        await self.hass.async_add_executor_job(self.set_fan_mode, fan_mode)
+
+    def set_fan_mode(self, fan_mode):
+        """Set the fan mode by calling set_fan_speed."""
+        self.set_fan_speed(fan_mode)
+
+    def _refresh_state(self):
+        """Schedule an immediate refresh of coordinator data on the event loop."""
+        if self.hass and self.hass.loop:
+            asyncio.run_coroutine_threadsafe(
+                self.coordinator.async_request_refresh(), self.hass.loop
+            )
+
+    def turn_on(self):
+        """Turn on the device by sending P1=1 and refresh state."""
+        self._send_command("P1", 1)
+        self._refresh_state()
+
+    def turn_off(self):
+        """Turn off the device by sending P1=0 and refresh state."""
+        self._send_command("P1", 0)
+        self._hvac_mode = HVACMode.OFF
+        self._refresh_state()
+
+    def set_hvac_mode(self, hvac_mode):
+        """Set the HVAC mode.
+        
+        Mapping:
+         - HVACMode.OFF: call turn_off() and return.
+         - HVACMode.COOL -> P2=1
+         - HVACMode.HEAT -> P2=2
+         - HVACMode.FAN_ONLY -> P2=3
+         - HVACMode.DRY -> P2=5
+         - HVACMode.AUTO -> P2=4
+        """
+        if self._hvac_mode == HVACMode.OFF and hvac_mode != HVACMode.OFF:
+            self.turn_on()
+        if hvac_mode == HVACMode.OFF:
+            self.turn_off()
+            return
+        mode_mapping = {
+            HVACMode.COOL: "1",
+            HVACMode.HEAT: "2",
+            HVACMode.FAN_ONLY: "3",
+            HVACMode.DRY: "5",
+            HVACMode.AUTO: "4",
+        }
+        if hvac_mode in mode_mapping:
+            self._send_command("P2", mode_mapping[hvac_mode])
+            self._hvac_mode = hvac_mode
+            self._refresh_state()
+        else:
+            _LOGGER.error("Unsupported HVAC mode: %s", hvac_mode)
+
+    def set_temperature(self, **kwargs):
+        """Set the target temperature.
+        
+        Must be called after changing the mode.
+        For HEAT or AUTO modes, use P8; for COOL mode use P7.
+        Temperature adjustments are disabled in DRY and FAN_ONLY modes.
+        The value is constrained to the device limits and sent as an integer with '.0' appended.
+        """
+        if self._hvac_mode in [HVACMode.DRY, HVACMode.FAN_ONLY]:
+            _LOGGER.warning("Temperature adjustment not supported in mode %s", self._hvac_mode)
+            return
+        temp = kwargs.get(ATTR_TEMPERATURE)
+        if temp is not None:
+            temp = int(float(temp))
+            if self._hvac_mode in [HVACMode.HEAT, HVACMode.AUTO]:
+                min_temp = int(float(self._device_data.get("min_limit_heat", 16)))
+                max_temp = int(float(self._device_data.get("max_limit_heat", 32)))
+                command = "P8"
+            else:
+                min_temp = int(float(self._device_data.get("min_limit_cold", 16)))
+                max_temp = int(float(self._device_data.get("max_limit_cold", 32)))
+                command = "P7"
+            if temp < min_temp:
+                temp = min_temp
+            elif temp > max_temp:
+                temp = max_temp
+            self._send_command(command, f"{temp}.0")
+            self._target_temperature = temp
+            self._refresh_state()
+
+    def set_fan_speed(self, speed):
+        """Set the fan speed.
+        
+        Uses P3 to adjust fan speed in COOL and FAN_ONLY modes and P4 in HEAT/AUTO modes.
+        In DRY mode, fan speed adjustments are disabled.
+        """
+        try:
+            speed = int(speed)
+        except ValueError:
+            _LOGGER.error("Invalid fan speed: %s", speed)
+            return
+        if speed not in self.fan_speed_range:
+            _LOGGER.error("Fan speed %s not in valid range %s", speed, self.fan_speed_range)
+            return
+        if self._hvac_mode in [HVACMode.COOL, HVACMode.FAN_ONLY]:
+            self._send_command("P3", speed)
+        elif self._hvac_mode in [HVACMode.HEAT, HVACMode.AUTO]:
+            self._send_command("P4", speed)
+        else:
+            _LOGGER.warning("Fan speed adjustment not supported in mode %s", self._hvac_mode)
+            return
+        self._fan_mode = str(speed)
+        self._refresh_state()
+
+    @property
+    def fan_speed_range(self):
+        """Return a list of valid fan speeds based on 'availables_speeds' from device data."""
+        speeds_str = self._device_data.get("availables_speeds", "3")
+        try:
+            speeds = int(speeds_str)
+        except ValueError:
+            speeds = 3
+        return list(range(1, speeds + 1))
+
+    def _send_command(self, option, value):
+        """Send a command to the device using the events endpoint."""
+        payload = {
+            "event": {
+                "cgi": "modmaquina",
+                "device_id": self._device_data.get("id"),
+                "option": option,
+                "value": value,
+            }
+        }
+        _LOGGER.info("Sending command: %s", payload)
+        if self.hass and self.hass.loop:
+            asyncio.run_coroutine_threadsafe(
+                self._api.send_event(payload), self.hass.loop
+            )
+        else:
+            _LOGGER.error("No hass loop available; cannot send command.")
+            

--- a/custom_components/airzoneclouddaikin/climate.py
+++ b/custom_components/airzoneclouddaikin/climate.py
@@ -1,338 +1,80 @@
-"""Climate platform for DKN Cloud for HASS using the Airzone Cloud API with DataUpdateCoordinator."""
-import asyncio
-import hashlib
-import json
+"""DKN Cloud for HASS integration."""
 import logging
+from datetime import timedelta
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from homeassistant.components.climate import ClimateEntity
-from homeassistant.components.climate.const import ClimateEntityFeature, HVACMode
-from homeassistant.const import UnitOfTemperature, ATTR_TEMPERATURE
 from .const import DOMAIN
+from .airzone_api import AirzoneAPI
 
 _LOGGER = logging.getLogger(__name__)
 
-async def async_setup_entry(hass, entry, async_add_entities):
-    """Set up the climate platform from a config entry using the DataUpdateCoordinator."""
-    data = hass.data[DOMAIN].get(entry.entry_id)
-    if not data:
-        _LOGGER.error("No data found in hass.data for entry %s", entry.entry_id)
-        return
-    coordinator = data.get("coordinator")
-    api = data.get("api")
+async def _async_update_data(api: AirzoneAPI) -> dict:
+    """Fetch and aggregate device data from the API.
+
+    This function fetches installations and then, for each installation,
+    fetches all devices. The data is aggregated into a dictionary keyed by device id.
+    """
+    data = {}
+    installations = await api.fetch_installations()
+    for relation in installations:
+        installation = relation.get("installation")
+        if not installation:
+            continue
+        installation_id = installation.get("id")
+        if not installation_id:
+            continue
+        devices = await api.fetch_devices(installation_id)
+        for device in devices:
+            device_id = device.get("id")
+            if not device_id:
+                # Fallback: use a hash of the device data if no id is provided.
+                device_id = f"{hash(str(device))}"
+                device["id"] = device_id
+            data[device_id] = device
+    return data
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up DKN Cloud for HASS from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
     config = entry.data
-    entities = []
-    # Create a ClimateEntity for each device in the coordinator's data.
-    for device_id, device in coordinator.data.items():
-        entities.append(AirzoneClimate(coordinator, api, device, config, hass))
-    async_add_entities(entities, True)
 
-class AirzoneClimate(ClimateEntity):
-    """Representation of an Airzone Cloud Daikin climate device."""
+    from homeassistant.helpers.aiohttp_client import async_get_clientsession
+    session = async_get_clientsession(hass)
+    api = AirzoneAPI(config.get("username"), config.get("password"), session)
+    if not await api.login():
+        _LOGGER.error("Login to Airzone API failed.")
+        return False
 
-    def __init__(self, coordinator, api, device_data: dict, config: dict, hass):
-        """
-        Initialize the climate entity.
+    # Hard-code update interval to 10 seconds.
+    coordinator = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name="airzone_data",
+        update_method=lambda: _async_update_data(api),
+        update_interval=timedelta(seconds=10),
+    )
+    # Attach the API instance to the coordinator so that entities can use it.
+    coordinator.api = api
 
-        :param coordinator: DataUpdateCoordinator instance.
-        :param api: AirzoneAPI instance.
-        :param device_data: Dictionary containing device information.
-        :param config: Integration configuration.
-        :param hass: Home Assistant instance.
-        """
-        self.coordinator = coordinator
-        self._api = api
-        # Work with a copy to avoid modifying the original coordinator data.
-        self._device_data = device_data.copy()
-        self._config = config
-        self.hass = hass
+    try:
+        await coordinator.async_config_entry_first_refresh()
+    except Exception as err:
+        _LOGGER.error("Failed to fetch initial data: %s", err)
+        raise UpdateFailed(err) from err
 
-        # Set entity name using the "name" field; default to "Airzone Device".
-        self._attr_name = self._device_data.get("name", "Airzone Device")
+    hass.data[DOMAIN][entry.entry_id] = {"api": api, "coordinator": coordinator}
+    # Forward setups for climate, sensor, and switch platforms.
+    await hass.config_entries.async_forward_entry_setups(entry, ["climate", "sensor", "switch"])
+    _LOGGER.info("DKN Cloud for HASS integration configured successfully.")
+    return True
 
-        # Ensure unique_id is generated in a stable manner.
-        device_id = self._device_data.get("id")
-        if not device_id or not str(device_id).strip():
-            # Generate a stable id based on static fields (name, mac, pin)
-            static_fields = {
-                "name": self._device_data.get("name"),
-                "mac": self._device_data.get("mac"),
-                "pin": self._device_data.get("pin")
-            }
-            device_id = hashlib.sha256(json.dumps(static_fields, sort_keys=True).encode("utf-8")).hexdigest()
-            self._device_data["id"] = device_id  # update for future use
-        self._attr_unique_id = device_id
-
-        self._attr_temperature_unit = UnitOfTemperature.CELSIUS
-        self._hvac_mode = HVACMode.OFF
-        self._target_temperature = None
-        self._fan_mode = None
-
-    @property
-    def hvac_modes(self):
-        """Return the list of supported HVAC modes."""
-        modes = [HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT, HVACMode.FAN_ONLY, HVACMode.DRY]
-        if self._config.get("force_hvac_mode_auto", False):
-            modes.append(HVACMode.AUTO)
-        return modes
-
-    @property
-    def hvac_mode(self):
-        """Return the current HVAC mode."""
-        return self._hvac_mode
-
-    @property
-    def target_temperature(self):
-        """Return the target temperature (or None if not applicable)."""
-        if self._hvac_mode in [HVACMode.OFF, HVACMode.DRY, HVACMode.FAN_ONLY]:
-            return None
-        return self._target_temperature
-
-    @property
-    def supported_features(self):
-        """Return supported features based on the current mode."""
-        if self._hvac_mode in [HVACMode.OFF, HVACMode.DRY]:
-            return 0
-        elif self._hvac_mode == HVACMode.FAN_ONLY:
-            return ClimateEntityFeature.FAN_MODE
-        else:
-            return ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
-
-    @property
-    def fan_modes(self):
-        """Return a list of valid fan speeds (as strings) based on the 'availables_speeds' field."""
-        speeds = self.fan_speed_range
-        return [str(speed) for speed in speeds]
-
-    @property
-    def fan_mode(self):
-        """Return the current fan mode, or None if not available."""
-        if self._hvac_mode in [HVACMode.OFF, HVACMode.DRY]:
-            return None
-        return self._fan_mode
-
-    @property
-    def device_info(self):
-        """Return device info for the device registry."""
-        return {
-            "identifiers": {(DOMAIN, self._device_data.get("id"))},
-            "name": self._device_data.get("name"),
-            "manufacturer": "Daikin",
-            "model": self._device_data.get("brand", "Unknown"),
-            "sw_version": self._device_data.get("firmware", "Unknown"),
-            "via_device": (DOMAIN, self._device_data.get("id")),
-        }
-
-    async def async_update(self):
-        """Update the entity from the coordinator without altering the unique_id."""
-        await self.coordinator.async_request_refresh()
-
-        # Try to fetch updated data using the stable unique_id.
-        updated_device = self.coordinator.data.get(self._attr_unique_id)
-        if not updated_device:
-            # Fallback: search for a device with the same name.
-            for dev in self.coordinator.data.values():
-                if dev.get("name") == self._attr_name:
-                    updated_device = dev
-                    break
-
-        if updated_device:
-            # Update only dynamic properties
-            dynamic_fields = [
-                "power",
-                "mode",
-                "cold_consign",
-                "heat_consign",
-                "cold_speed",
-                "heat_speed",
-                "min_limit_cold",
-                "max_limit_cold",
-                "min_limit_heat",
-                "max_limit_heat",
-            ]
-            for field in dynamic_fields:
-                self._device_data[field] = updated_device.get(field)
-
-            if int(updated_device.get("power", 0)) == 1:
-                mode_val = updated_device.get("mode")
-                if mode_val == "1":
-                    self._hvac_mode = HVACMode.COOL
-                    self._target_temperature = int(float(updated_device.get("cold_consign", "0")))
-                    self._fan_mode = str(updated_device.get("cold_speed", ""))
-                elif mode_val == "2":
-                    self._hvac_mode = HVACMode.HEAT
-                    self._target_temperature = int(float(updated_device.get("heat_consign", "0")))
-                    self._fan_mode = str(updated_device.get("heat_speed", ""))
-                elif mode_val == "3":
-                    self._hvac_mode = HVACMode.FAN_ONLY
-                    self._target_temperature = None
-                    self._fan_mode = str(updated_device.get("cold_speed", ""))
-                elif mode_val == "5":
-                    self._hvac_mode = HVACMode.DRY
-                    self._target_temperature = None
-                    self._fan_mode = None
-                elif mode_val == "4":
-                    self._hvac_mode = HVACMode.AUTO
-                    self._target_temperature = int(float(updated_device.get("heat_consign", "0")))
-                    self._fan_mode = str(updated_device.get("heat_speed", ""))
-                else:
-                    # Default fallback to HEAT mode
-                    self._hvac_mode = HVACMode.HEAT
-                    self._target_temperature = int(float(updated_device.get("heat_consign", "0")))
-                    self._fan_mode = str(updated_device.get("heat_speed", ""))
-            else:
-                self._hvac_mode = HVACMode.OFF
-                self._target_temperature = None
-                self._fan_mode = None
-        self.async_write_ha_state()
-
-    async def async_set_hvac_mode(self, hvac_mode):
-        """Set the HVAC mode asynchronously and update the UI immediately."""
-        if hvac_mode == HVACMode.OFF:
-            self._hvac_mode = HVACMode.OFF
-            self._target_temperature = None
-            self._fan_mode = None
-            self._send_command("P1", 0)
-        else:
-            # If device is off, power it on first.
-            if self._hvac_mode == HVACMode.OFF:
-                self._hvac_mode = hvac_mode
-                self._send_command("P1", 1)
-                await asyncio.sleep(1)  # Wait 1 second for the device to turn on
-            mode_mapping = {
-                HVACMode.COOL: "1",
-                HVACMode.HEAT: "2",
-                HVACMode.FAN_ONLY: "3",
-                HVACMode.DRY: "5",
-                HVACMode.AUTO: "4",
-            }
-            if hvac_mode in mode_mapping:
-                self._send_command("P2", mode_mapping[hvac_mode])
-                self._hvac_mode = hvac_mode
-            else:
-                _LOGGER.error("Unsupported HVAC mode: %s", hvac_mode)
-        self.async_write_ha_state()
-        self._refresh_state()
-
-    async def async_set_temperature(self, **kwargs):
-        """Set the target temperature asynchronously.
-
-        Does nothing if the current mode does not support temperature control.
-        """
-        if self._hvac_mode in [HVACMode.DRY, HVACMode.FAN_ONLY, HVACMode.OFF]:
-            _LOGGER.warning("Temperature adjustment not supported in mode %s", self._hvac_mode)
-            return
-        temp = kwargs.get(ATTR_TEMPERATURE)
-        if temp is not None:
-            temp = int(float(temp))
-            if self._hvac_mode in [HVACMode.HEAT, HVACMode.AUTO]:
-                min_temp = int(float(self._device_data.get("min_limit_heat", 16)))
-                max_temp = int(float(self._device_data.get("max_limit_heat", 32)))
-                command = "P8"
-            else:
-                min_temp = int(float(self._device_data.get("min_limit_cold", 16)))
-                max_temp = int(float(self._device_data.get("max_limit_cold", 32)))
-                command = "P7"
-            if temp < min_temp:
-                temp = min_temp
-            elif temp > max_temp:
-                temp = max_temp
-            self._send_command(command, f"{temp}.0")
-            self._target_temperature = temp
-            self.async_write_ha_state()
-            self._refresh_state()
-
-    async def async_set_fan_mode(self, fan_mode):
-        """Set the fan mode asynchronously.
-
-        Does nothing if fan control is not supported in the current mode.
-        """
-        if self._hvac_mode in [HVACMode.DRY, HVACMode.OFF]:
-            _LOGGER.warning("Fan control not supported in mode %s", self._hvac_mode)
-            return
-        await self.hass.async_add_executor_job(self.set_fan_mode, fan_mode)
-        self.async_write_ha_state()
-        self._refresh_state()
-
-    def set_fan_mode(self, fan_mode):
-        """Delegate fan mode setting to set_fan_speed."""
-        self.set_fan_speed(fan_mode)
-
-    def _refresh_state(self):
-        """Force an immediate refresh of the coordinator data."""
-        if self.hass and self.hass.loop:
-            try:
-                asyncio.run_coroutine_threadsafe(
-                    self.coordinator.async_request_refresh(), self.hass.loop
-                ).result()
-            except Exception as err:
-                _LOGGER.error("Error refreshing state: %s", err)
-
-    def turn_on(self):
-        """Turn on the device by sending P1=1 and refresh the state."""
-        self._send_command("P1", 1)
-        self._refresh_state()
-
-    def turn_off(self):
-        """Turn off the device by sending P1=0, reset mode, and refresh the state."""
-        self._send_command("P1", 0)
-        self._hvac_mode = HVACMode.OFF
-        self._target_temperature = None
-        self._fan_mode = None
-        self._refresh_state()
-
-    def set_fan_speed(self, speed):
-        """Set the fan speed.
-
-        Uses P3 for COOL/FAN_ONLY modes and P4 for HEAT/AUTO modes.
-        """
-        try:
-            speed = int(speed)
-        except ValueError:
-            _LOGGER.error("Invalid fan speed: %s", speed)
-            return
-        if speed not in self.fan_speed_range:
-            _LOGGER.error("Fan speed %s not in valid range %s", speed, self.fan_speed_range)
-            return
-        if self._hvac_mode in [HVACMode.COOL, HVACMode.FAN_ONLY]:
-            self._send_command("P3", speed)
-        elif self._hvac_mode in [HVACMode.HEAT, HVACMode.AUTO]:
-            self._send_command("P4", speed)
-        else:
-            _LOGGER.warning("Fan speed adjustment not supported in mode %s", self._hvac_mode)
-            return
-        self._fan_mode = str(speed)
-        self.async_write_ha_state()
-        self._refresh_state()
-
-    @property
-    def fan_speed_range(self):
-        """Return a list of valid fan speeds based on the 'availables_speeds' field from device data."""
-        speeds_str = self._device_data.get("availables_speeds", "3")
-        try:
-            speeds = int(speeds_str)
-        except ValueError:
-            speeds = 3
-        return list(range(1, speeds + 1))
-
-    def _send_command(self, option, value):
-        """Send a command to the device using the events endpoint and wait for completion."""
-        payload = {
-            "event": {
-                "cgi": "modmaquina",
-                "device_id": self._device_data.get("id"),
-                "option": option,
-                "value": value,
-            }
-        }
-        _LOGGER.info("Sending command: %s", payload)
-        if self.hass and self.hass.loop:
-            try:
-                # Wait for the API response.
-                asyncio.run_coroutine_threadsafe(
-                    self._api.send_event(payload), self.hass.loop
-                ).result()
-            except Exception as err:
-                _LOGGER.error("Error sending command: %s", err)
-        else:
-            _LOGGER.error("No hass loop available; cannot send command.")
-        self._refresh_state()
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_forward_entry_unload(entry, "climate")
+    unload_ok = unload_ok and await hass.config_entries.async_forward_entry_unload(entry, "sensor")
+    unload_ok = unload_ok and await hass.config_entries.async_forward_entry_unload(entry, "switch")
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+    return unload_ok

--- a/custom_components/airzoneclouddaikin/climate.py
+++ b/custom_components/airzoneclouddaikin/climate.py
@@ -1,258 +1,84 @@
-"""Climate platform for DKN Cloud for HASS using the Airzone Cloud API."""
-import asyncio
+"""DKN Cloud for HASS integration."""
 import logging
-from homeassistant.components.climate import ClimateEntity
-from homeassistant.components.climate.const import ClimateEntityFeature, HVACMode
-from homeassistant.const import UnitOfTemperature, ATTR_TEMPERATURE
+from datetime import timedelta
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
 from .const import DOMAIN
+from .airzone_api import AirzoneAPI
+
 _LOGGER = logging.getLogger(__name__)
 
-async def async_setup_entry(hass, entry, async_add_entities):
-    """Set up the climate platform from a config entry using the DataUpdateCoordinator."""
-    data = hass.data[DOMAIN].get(entry.entry_id)
-    if not data:
-        _LOGGER.error("No data found in hass.data for entry %s", entry.entry_id)
-        return
-    coordinator = data.get("coordinator")
-    api = data.get("api")
+async def _async_update_data(api: AirzoneAPI) -> dict:
+    """Fetch and aggregate device data from the API.
+
+    This function fetches installations and then, for each installation,
+    fetches all devices. The data is aggregated into a dictionary keyed by device id.
+    """
+    data = {}
+    installations = await api.fetch_installations()
+    for relation in installations:
+        installation = relation.get("installation")
+        if not installation:
+            continue
+        installation_id = installation.get("id")
+        if not installation_id:
+            continue
+        devices = await api.fetch_devices(installation_id)
+        for device in devices:
+            device_id = device.get("id")
+            if not device_id:
+                # Fallback: use a hash of the device data if no id is provided
+                device_id = f"{hash(str(device))}"
+                device["id"] = device_id
+            data[device_id] = device
+    return data
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up DKN Cloud for HASS from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
     config = entry.data
-    climates = []
-    # Create a climate entity for each device in the coordinator data.
-    for device_id, device in coordinator.data.items():
-        climates.append(AirzoneClimate(coordinator, api, device, config, hass))
-    async_add_entities(climates, True)
 
-class AirzoneClimate(ClimateEntity):
-    """Representation of an Airzone Cloud Daikin climate device."""
+    from homeassistant.helpers.aiohttp_client import async_get_clientsession
+    session = async_get_clientsession(hass)
+    api = AirzoneAPI(config.get("username"), config.get("password"), session)
+    if not await api.login():
+        _LOGGER.error("Login to Airzone API failed.")
+        return False
 
-    def __init__(self, coordinator, api, device_data: dict, config: dict, hass):
-        """Initialize the climate entity.
-        
-        :param coordinator: The DataUpdateCoordinator instance.
-        :param api: The AirzoneAPI instance.
-        :param device_data: Dictionary with device information.
-        :param config: Integration configuration.
-        :param hass: Home Assistant instance.
-        """
-        self.coordinator = coordinator
-        self._api = api
-        self._device_data = device_data
-        self._config = config
-        self.hass = hass
-        self._attr_name = device_data.get("name", "Airzone Device")
-        # Use the device id as unique_id (it is ensured to exist in coordinator update)
-        self._attr_unique_id = device_data.get("id")
-        self._attr_temperature_unit = UnitOfTemperature.CELSIUS
-        self._hvac_mode = HVACMode.OFF
-        self._target_temperature = None
-        self._fan_mode = None
+    # Use a default scan interval of 10 seconds (minimum 10 seconds)
+    scan_interval = config.get("scan_interval", 10)
+    if scan_interval < 10:
+        scan_interval = 10
 
-    @property
-    def hvac_modes(self):
-        """Return the list of supported HVAC modes."""
-        modes = [HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT, HVACMode.FAN_ONLY, HVACMode.DRY]
-        if self._config.get("force_hvac_mode_auto", False):
-            modes.append(HVACMode.AUTO)
-        return modes
+    coordinator = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name="airzone_data",
+        update_method=lambda: _async_update_data(api),
+        update_interval=timedelta(seconds=scan_interval),
+    )
+    # Attach the API instance to the coordinator so that entities can use it.
+    coordinator.api = api
 
-    @property
-    def hvac_mode(self):
-        """Return the current HVAC mode."""
-        return self._hvac_mode
+    try:
+        await coordinator.async_config_entry_first_refresh()
+    except Exception as err:
+        _LOGGER.error("Failed to fetch initial data: %s", err)
+        raise UpdateFailed(err) from err
 
-    @property
-    def target_temperature(self):
-        """Return the current target temperature."""
-        return self._target_temperature
+    hass.data[DOMAIN][entry.entry_id] = {"api": api, "coordinator": coordinator}
+    # Forward setups for climate, sensor, and switch platforms.
+    await hass.config_entries.async_forward_entry_setups(entry, ["climate", "sensor", "switch"])
+    _LOGGER.info("DKN Cloud for HASS integration configured successfully.")
+    return True
 
-    @property
-    def supported_features(self):
-        """Return supported features: target temperature and fan mode."""
-        return ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
-
-    @property
-    def fan_modes(self):
-        """Return a list of valid fan speeds as strings based on 'availables_speeds'."""
-        speeds = self.fan_speed_range
-        return [str(speed) for speed in speeds]
-
-    @property
-    def fan_mode(self):
-        """Return the current fan speed."""
-        return self._fan_mode
-
-    @property
-    def device_info(self):
-        """Return device info to group this entity with others in the device registry."""
-        return {
-            "identifiers": {(DOMAIN, self._device_data.get("id"))},
-            "name": self._device_data.get("name"),
-            "manufacturer": "Daikin",
-            "model": self._device_data.get("brand", "Unknown"),
-            "sw_version": self._device_data.get("firmware", "Unknown"),
-            "via_device": (DOMAIN, self._device_data.get("id")),
-        }
-
-    async def async_update(self):
-        """Update the climate entity from the coordinator data."""
-        await self.coordinator.async_request_refresh()
-        device = self.coordinator.data.get(self._device_data.get("id"))
-        if device:
-            self._device_data = device
-            if int(device.get("power", 0)) == 1:
-                mode_val = device.get("mode")
-                if mode_val == "1":
-                    self._hvac_mode = HVACMode.COOL
-                    self._target_temperature = int(float(device.get("cold_consign", "0")))
-                    self._fan_mode = str(device.get("cold_speed", ""))
-                elif mode_val == "2":
-                    self._hvac_mode = HVACMode.HEAT
-                    self._target_temperature = int(float(device.get("heat_consign", "0")))
-                    self._fan_mode = str(device.get("heat_speed", ""))
-                elif mode_val == "3":
-                    self._hvac_mode = HVACMode.FAN_ONLY
-                    self._fan_mode = str(device.get("cold_speed", ""))
-                elif mode_val == "5":
-                    self._hvac_mode = HVACMode.DRY
-                    self._fan_mode = ""
-                elif mode_val == "4":
-                    self._hvac_mode = HVACMode.AUTO
-                    self._target_temperature = int(float(device.get("heat_consign", "0")))
-                    self._fan_mode = str(device.get("heat_speed", ""))
-                else:
-                    self._hvac_mode = HVACMode.HEAT
-                    self._target_temperature = int(float(device.get("heat_consign", "0")))
-                    self._fan_mode = str(device.get("heat_speed", ""))
-            else:
-                self._hvac_mode = HVACMode.OFF
-        # State update is handled by the coordinator; no direct call to async_write_ha_state() here.
-
-    def _refresh_state(self):
-        """Schedule an immediate refresh of coordinator data on the event loop."""
-        if self.hass and self.hass.loop:
-            asyncio.run_coroutine_threadsafe(
-                self.coordinator.async_request_refresh(), self.hass.loop
-            )
-
-    def turn_on(self):
-        """Turn on the device by sending P1=1 and refresh state."""
-        self._send_command("P1", 1)
-        self._refresh_state()
-
-    def turn_off(self):
-        """Turn off the device by sending P1=0 and refresh state."""
-        self._send_command("P1", 0)
-        self._hvac_mode = HVACMode.OFF
-        self._refresh_state()
-
-    def set_hvac_mode(self, hvac_mode):
-        """Set the HVAC mode.
-        
-        Mapping:
-         - HVACMode.OFF: call turn_off() and return.
-         - HVACMode.COOL -> P2=1
-         - HVACMode.HEAT -> P2=2
-         - HVACMode.FAN_ONLY -> P2=3
-         - HVACMode.DRY -> P2=5
-         - HVACMode.AUTO -> P2=4
-        """
-        if self._hvac_mode == HVACMode.OFF and hvac_mode != HVACMode.OFF:
-            self.turn_on()
-        if hvac_mode == HVACMode.OFF:
-            self.turn_off()
-            return
-        mode_mapping = {
-            HVACMode.COOL: "1",
-            HVACMode.HEAT: "2",
-            HVACMode.FAN_ONLY: "3",
-            HVACMode.DRY: "5",
-            HVACMode.AUTO: "4",
-        }
-        if hvac_mode in mode_mapping:
-            self._send_command("P2", mode_mapping[hvac_mode])
-            self._hvac_mode = hvac_mode
-            self._refresh_state()
-        else:
-            _LOGGER.error("Unsupported HVAC mode: %s", hvac_mode)
-
-    def set_temperature(self, **kwargs):
-        """Set the target temperature.
-        
-        Must be called after changing the mode.
-        For HEAT or AUTO modes, use P8; for COOL mode use P7.
-        Temperature adjustments are disabled in DRY and FAN_ONLY modes.
-        The value is constrained to the device limits and sent as an integer with '.0' appended.
-        """
-        if self._hvac_mode in [HVACMode.DRY, HVACMode.FAN_ONLY]:
-            _LOGGER.warning("Temperature adjustment not supported in mode %s", self._hvac_mode)
-            return
-        temp = kwargs.get(ATTR_TEMPERATURE)
-        if temp is not None:
-            temp = int(float(temp))
-            if self._hvac_mode in [HVACMode.HEAT, HVACMode.AUTO]:
-                min_temp = int(float(self._device_data.get("min_limit_heat", 16)))
-                max_temp = int(float(self._device_data.get("max_limit_heat", 32)))
-                command = "P8"
-            else:
-                min_temp = int(float(self._device_data.get("min_limit_cold", 16)))
-                max_temp = int(float(self._device_data.get("max_limit_cold", 32)))
-                command = "P7"
-            if temp < min_temp:
-                temp = min_temp
-            elif temp > max_temp:
-                temp = max_temp
-            self._send_command(command, f"{temp}.0")
-            self._target_temperature = temp
-            self._refresh_state()
-
-    def set_fan_speed(self, speed):
-        """Set the fan speed.
-        
-        Uses P3 to adjust fan speed in COOL and FAN_ONLY modes and P4 in HEAT/AUTO modes.
-        In DRY mode, fan speed adjustments are disabled.
-        """
-        try:
-            speed = int(speed)
-        except ValueError:
-            _LOGGER.error("Invalid fan speed: %s", speed)
-            return
-        if speed not in self.fan_speed_range:
-            _LOGGER.error("Fan speed %s not in valid range %s", speed, self.fan_speed_range)
-            return
-        if self._hvac_mode in [HVACMode.COOL, HVACMode.FAN_ONLY]:
-            self._send_command("P3", speed)
-        elif self._hvac_mode in [HVACMode.HEAT, HVACMode.AUTO]:
-            self._send_command("P4", speed)
-        else:
-            _LOGGER.warning("Fan speed adjustment not supported in mode %s", self._hvac_mode)
-            return
-        self._fan_mode = str(speed)
-        self._refresh_state()
-
-    @property
-    def fan_speed_range(self):
-        """Return a list of valid fan speeds based on 'availables_speeds' from device data."""
-        speeds_str = self._device_data.get("availables_speeds", "3")
-        try:
-            speeds = int(speeds_str)
-        except ValueError:
-            speeds = 3
-        return list(range(1, speeds + 1))
-
-    def _send_command(self, option, value):
-        """Send a command to the device using the events endpoint."""
-        payload = {
-            "event": {
-                "cgi": "modmaquina",
-                "device_id": self._device_data.get("id"),
-                "option": option,
-                "value": value,
-            }
-        }
-        _LOGGER.info("Sending command: %s", payload)
-        if self.hass and self.hass.loop:
-            asyncio.run_coroutine_threadsafe(
-                self._api.send_event(payload), self.hass.loop
-            )
-        else:
-            _LOGGER.error("No hass loop available; cannot send command.")
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_forward_entry_unload(entry, "climate")
+    unload_ok = unload_ok and await hass.config_entries.async_forward_entry_unload(entry, "sensor")
+    unload_ok = unload_ok and await hass.config_entries.async_forward_entry_unload(entry, "switch")
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+    return unload_ok

--- a/custom_components/airzoneclouddaikin/climate.py
+++ b/custom_components/airzoneclouddaikin/climate.py
@@ -74,7 +74,7 @@ class AirzoneClimate(ClimateEntity):
     @property
     def supported_features(self):
         """Return supported features as a set.
-
+        
         - In OFF and DRY modes: no temperature or fan controls.
         - In FAN_ONLY mode: only fan control.
         - Otherwise: temperature and fan control.
@@ -95,7 +95,7 @@ class AirzoneClimate(ClimateEntity):
     @property
     def fan_mode(self):
         """Return the current fan speed.
-
+        
         In DRY or OFF modes, no fan mode is applicable.
         """
         if self._hvac_mode in {HVACMode.DRY, HVACMode.OFF}:
@@ -150,20 +150,20 @@ class AirzoneClimate(ClimateEntity):
                 self._hvac_mode = HVACMode.OFF
                 self._target_temperature = None
                 self._fan_mode = None
-        # We don't call async_write_ha_state here; the coordinator will update the entity.
+        # The coordinator will update the state automatically.
 
     async def async_set_fan_mode(self, fan_mode):
         """Set the fan mode asynchronously (delegates to set_fan_speed)."""
         await self.hass.async_add_executor_job(self.set_fan_mode, fan_mode)
-        self.hass.async_create_task(self.async_write_ha_state())
+        self.hass.async_run_job(self.async_write_ha_state)
 
     def set_fan_mode(self, fan_mode):
         """Set the fan mode by calling set_fan_speed."""
         self.set_fan_speed(fan_mode)
 
     def _update_local_state(self):
-        """Schedule an immediate state update."""
-        self.hass.async_create_task(self.async_write_ha_state())
+        """Schedule an immediate state update in a thread-safe way."""
+        self.hass.async_run_job(self.async_write_ha_state)
 
     def turn_on(self):
         """Turn on the device by sending P1=1 and update local state immediately."""
@@ -182,7 +182,7 @@ class AirzoneClimate(ClimateEntity):
 
     def set_hvac_mode(self, hvac_mode):
         """Set the HVAC mode.
-
+        
         Mapping:
          - HVACMode.OFF: call turn_off() and return.
          - HVACMode.COOL -> P2=1

--- a/custom_components/airzoneclouddaikin/climate.py
+++ b/custom_components/airzoneclouddaikin/climate.py
@@ -37,6 +37,7 @@ class AirzoneClimate(ClimateEntity):
         self._device_data = device_data
         self._config = config
         self._attr_name = device_data.get("name", "Airzone Device")
+        # Set unique_id using the device id
         self._attr_unique_id = device_data.get("id")
         self._attr_temperature_unit = UnitOfTemperature.CELSIUS
         self._hvac_mode = HVACMode.OFF
@@ -121,18 +122,18 @@ class AirzoneClimate(ClimateEntity):
                     self._fan_mode = str(device.get("heat_speed", ""))
             else:
                 self._hvac_mode = HVACMode.OFF
-        self.async_write_ha_state()
+        # Do not call async_write_ha_state() here; HA will update state automatically after coordinator refresh.
 
     def turn_on(self):
         """Turn on the device by sending P1=1."""
         self._send_command("P1", 1)
-        self.async_write_ha_state()
+        # No direct call to async_write_ha_state() here.
 
     def turn_off(self):
         """Turn off the device by sending P1=0."""
         self._send_command("P1", 0)
         self._hvac_mode = HVACMode.OFF
-        self.async_write_ha_state()
+        # No direct call to async_write_ha_state() here.
 
     def set_hvac_mode(self, hvac_mode):
         """Set the HVAC mode.
@@ -160,7 +161,6 @@ class AirzoneClimate(ClimateEntity):
         if hvac_mode in mode_mapping:
             self._send_command("P2", mode_mapping[hvac_mode])
             self._hvac_mode = hvac_mode
-            self.async_write_ha_state()
         else:
             _LOGGER.error("Unsupported HVAC mode: %s", hvac_mode)
 
@@ -192,7 +192,6 @@ class AirzoneClimate(ClimateEntity):
                 temp = max_temp
             self._send_command(command, f"{temp}.0")
             self._target_temperature = temp
-            self.async_write_ha_state()
 
     def set_fan_speed(self, speed):
         """Set the fan speed.
@@ -216,7 +215,6 @@ class AirzoneClimate(ClimateEntity):
             _LOGGER.warning("Fan speed adjustment not supported in mode %s", self._hvac_mode)
             return
         self._fan_mode = str(speed)
-        self.async_write_ha_state()
 
     @property
     def fan_speed_range(self):

--- a/custom_components/airzoneclouddaikin/config_flow.py
+++ b/custom_components/airzoneclouddaikin/config_flow.py
@@ -5,15 +5,15 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from .const import DOMAIN
-from .airzone_api import AirzoneAPI
 
 _LOGGER = logging.getLogger(__name__)
 
+# Add scan_interval option (default 30 seconds, minimum 10)
 DATA_SCHEMA = vol.Schema({
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional("scan_interval", default=30): vol.All(vol.Coerce(int), vol.Range(min=10)),
     vol.Optional("force_hvac_mode_auto", default=False): bool,
 })
 
@@ -25,6 +25,9 @@ class AirzoneConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle a flow initiated by the user."""
         errors = {}
         if user_input is not None:
+            # Validate credentials by attempting a login
+            from homeassistant.helpers.aiohttp_client import async_get_clientsession
+            from .airzone_api import AirzoneAPI
             session = async_get_clientsession(self.hass)
             api = AirzoneAPI(user_input[CONF_USERNAME], user_input[CONF_PASSWORD], session)
             if not await api.login():

--- a/custom_components/airzoneclouddaikin/config_flow.py
+++ b/custom_components/airzoneclouddaikin/config_flow.py
@@ -37,5 +37,4 @@ class AirzoneConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     errors=errors,
                 )
             return self.async_create_entry(title="DKN Cloud for HASS", data=user_input)
-        return self.async_show_
-        form
+        return self.async_show_form

--- a/custom_components/airzoneclouddaikin/config_flow.py
+++ b/custom_components/airzoneclouddaikin/config_flow.py
@@ -37,4 +37,8 @@ class AirzoneConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     errors=errors,
                 )
             return self.async_create_entry(title="DKN Cloud for HASS", data=user_input)
-        return self.async_show_form
+        return self.async_show_form(
+            step_id="user",
+            data_schema=DATA_SCHEMA,
+            errors=errors,
+        )

--- a/custom_components/airzoneclouddaikin/config_flow.py
+++ b/custom_components/airzoneclouddaikin/config_flow.py
@@ -9,10 +9,10 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-# Remove scan_interval from the schema; the update interval is fixed at 10 seconds.
 DATA_SCHEMA = vol.Schema({
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional("scan_interval", default=10): vol.All(vol.Coerce(int), vol.Range(min=10)),
     vol.Optional("force_hvac_mode_auto", default=False): bool,
 })
 
@@ -37,8 +37,5 @@ class AirzoneConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     errors=errors,
                 )
             return self.async_create_entry(title="DKN Cloud for HASS", data=user_input)
-        return self.async_show_form(
-            step_id="user",
-            data_schema=DATA_SCHEMA,
-            errors=errors,
-        )
+        return self.async_show_
+        form

--- a/custom_components/airzoneclouddaikin/config_flow.py
+++ b/custom_components/airzoneclouddaikin/config_flow.py
@@ -9,11 +9,10 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-# Add scan_interval option (default 30 seconds, minimum 10)
+# Remove scan_interval from the schema; the update interval is fixed at 10 seconds.
 DATA_SCHEMA = vol.Schema({
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
-    vol.Optional("scan_interval", default=30): vol.All(vol.Coerce(int), vol.Range(min=10)),
     vol.Optional("force_hvac_mode_auto", default=False): bool,
 })
 

--- a/custom_components/airzoneclouddaikin/const.py
+++ b/custom_components/airzoneclouddaikin/const.py
@@ -17,6 +17,4 @@ API_EVENTS = "/events"
 BASE_URL = "https://dkn.airzonecloud.com"
 
 # Standard User-Agent to be used in all API requests
-USER_AGENT = ("Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-              "AppleWebKit/537.36 (KHTML, like Gecko) "
-              "Chrome/134.0.0.0 Safari/537.36")
+USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36"

--- a/custom_components/airzoneclouddaikin/manifest.json
+++ b/custom_components/airzoneclouddaikin/manifest.json
@@ -6,6 +6,6 @@
   "dependencies": [],
   "after_dependencies": ["http"],
   "codeowners": ["@max13fr", "eXPerience83"],
-  "version": "0.2.7.2",
+  "version": "0.2.7.4",
   "config_flow": true
 }

--- a/custom_components/airzoneclouddaikin/sensor.py
+++ b/custom_components/airzoneclouddaikin/sensor.py
@@ -9,14 +9,18 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    """Set up the sensor platform from a config entry using the DataUpdateCoordinator."""
+    """Set up the sensor platform from a config entry using the DataUpdateCoordinator.
+
+    This function retrieves the coordinator from hass.data and creates a sensor entity
+    for each device using the coordinator's data.
+    """
     data = hass.data[DOMAIN].get(entry.entry_id)
     if not data:
         _LOGGER.error("No data found in hass.data for entry %s", entry.entry_id)
         return
     coordinator = data.get("coordinator")
     sensors = []
-    # Create a sensor entity for each device in the coordinator data
+    # Create a sensor entity for each device in the coordinator data.
     for device_id, device in coordinator.data.items():
         sensors.append(AirzoneTemperatureSensor(coordinator, device))
     async_add_entities(sensors, True)
@@ -35,7 +39,7 @@ class AirzoneTemperatureSensor(SensorEntity):
         # Construct sensor name: "<Device Name> Temperature"
         name = f"{device_data.get('name', 'Airzone Device')} Temperature"
         self._attr_name = name
-        # Set unique_id using the device id plus a suffix
+        # Set unique_id using the device id plus a suffix.
         device_id = device_data.get("id")
         if device_id and device_id.strip():
             self._attr_unique_id = f"{device_id}_temperature"
@@ -71,8 +75,9 @@ class AirzoneTemperatureSensor(SensorEntity):
 
     async def async_update(self):
         """Update the sensor state from the coordinator data.
-        
-        This method requests a refresh of the coordinator data and updates the sensor state.
+
+        This method requests a refresh of the coordinator data and then updates
+        the sensor state using the latest device data.
         """
         await self.coordinator.async_request_refresh()
         # Retrieve the updated device data using its id
@@ -80,7 +85,7 @@ class AirzoneTemperatureSensor(SensorEntity):
         if device:
             self._device_data = device
         self.update_state()
-        self.async_write_ha_state()
+        # Do not call async_write_ha_state() here because HA will update the state automatically
 
     def update_state(self):
         """Update the native value from device data."""

--- a/custom_components/airzoneclouddaikin/sensor.py
+++ b/custom_components/airzoneclouddaikin/sensor.py
@@ -9,18 +9,14 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    """Set up the sensor platform from a config entry using the DataUpdateCoordinator.
-
-    This function retrieves the coordinator from hass.data and creates a sensor entity
-    for each device using the coordinator's data.
-    """
+    """Set up the sensor platform from a config entry using the DataUpdateCoordinator."""
     data = hass.data[DOMAIN].get(entry.entry_id)
     if not data:
         _LOGGER.error("No data found in hass.data for entry %s", entry.entry_id)
         return
     coordinator = data.get("coordinator")
     sensors = []
-    # Iterate over each device in the coordinator's data (keyed by device id)
+    # Create a sensor entity for each device in the coordinator data
     for device_id, device in coordinator.data.items():
         sensors.append(AirzoneTemperatureSensor(coordinator, device))
     async_add_entities(sensors, True)
@@ -39,29 +35,18 @@ class AirzoneTemperatureSensor(SensorEntity):
         # Construct sensor name: "<Device Name> Temperature"
         name = f"{device_data.get('name', 'Airzone Device')} Temperature"
         self._attr_name = name
-
-        # Use the device 'id' to form a unique id; if missing, fallback to a hash of the name.
+        # Set unique_id using the device id plus a suffix
         device_id = device_data.get("id")
         if device_id and device_id.strip():
             self._attr_unique_id = f"{device_id}_temperature"
         else:
             self._attr_unique_id = hashlib.sha256(name.encode("utf-8")).hexdigest()
-
-        # Set the unit attributes explicitly for HA statistics and display.
-        self._attr_unit_of_measurement = UnitOfTemperature.CELSIUS
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
-
-        # Set device class and state class for statistics
+        self._attr_unit_of_measurement = UnitOfTemperature.CELSIUS
         self._attr_device_class = "temperature"
         self._attr_state_class = "measurement"
         self._attr_icon = "mdi:thermometer"
-        # Initialize sensor state
         self.update_state()
-
-    @property
-    def unique_id(self):
-        """Return the unique id for this sensor."""
-        return self._attr_unique_id
 
     @property
     def native_value(self):
@@ -70,14 +55,14 @@ class AirzoneTemperatureSensor(SensorEntity):
 
     @property
     def accuracy_decimals(self):
-        """Return the number of decimals to use for the sensor state (display as integer)."""
+        """Return 0 to display the state as an integer (e.g., 22°C)."""
         return 0
 
     @property
     def device_info(self):
         """Return device info to link this sensor to a device in Home Assistant."""
         return {
-            "identifiers": { (DOMAIN, self._device_data.get("id")) },
+            "identifiers": {(DOMAIN, self._device_data.get("id"))},
             "name": self._device_data.get("name"),
             "manufacturer": "Daikin",
             "model": self._device_data.get("brand", "Unknown"),
@@ -86,17 +71,16 @@ class AirzoneTemperatureSensor(SensorEntity):
 
     async def async_update(self):
         """Update the sensor state from the coordinator data.
-
-        This method requests a refresh of the coordinator data and then updates
-        the sensor state using the latest device data.
+        
+        This method requests a refresh of the coordinator data and updates the sensor state.
         """
         await self.coordinator.async_request_refresh()
-        # Retrieve the updated device data using the device's unique id
+        # Retrieve the updated device data using its id
         device = self.coordinator.data.get(self._device_data.get("id"))
         if device:
             self._device_data = device
         self.update_state()
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     def update_state(self):
         """Update the native value from device data."""

--- a/custom_components/airzoneclouddaikin/sensor.py
+++ b/custom_components/airzoneclouddaikin/sensor.py
@@ -4,61 +4,58 @@ import logging
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import UnitOfTemperature
 
+from .const import DOMAIN
+
 _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    """Set up the sensor platform from a config entry."""
-    config = entry.data
-    from homeassistant.helpers.aiohttp_client import async_get_clientsession
-    session = async_get_clientsession(hass)
-    from .airzone_api import AirzoneAPI
-    api = AirzoneAPI(config.get("username"), config.get("password"), session)
-    if not await api.login():
-        _LOGGER.error("Login to Airzone API failed in sensor setup.")
+    """Set up the sensor platform from a config entry using the DataUpdateCoordinator.
+
+    This function retrieves the coordinator from hass.data and creates a sensor entity
+    for each device using the coordinator's data.
+    """
+    data = hass.data[DOMAIN].get(entry.entry_id)
+    if not data:
+        _LOGGER.error("No data found in hass.data for entry %s", entry.entry_id)
         return
-    installations = await api.fetch_installations()
+    coordinator = data.get("coordinator")
     sensors = []
-    for relation in installations:
-        installation = relation.get("installation")
-        if not installation:
-            continue
-        installation_id = installation.get("id")
-        if not installation_id:
-            continue
-        devices = await api.fetch_devices(installation_id)
-        for device in devices:
-            sensors.append(AirzoneTemperatureSensor(api, device))
-    async_add_entities(sensors)  # Let HA assign entity_id after adding entities.
+    # Iterate over each device in the coordinator's data (keyed by device id)
+    for device_id, device in coordinator.data.items():
+        sensors.append(AirzoneTemperatureSensor(coordinator, device))
+    async_add_entities(sensors, True)
 
 class AirzoneTemperatureSensor(SensorEntity):
     """Representation of a temperature sensor for an Airzone device (local_temp)."""
 
-    def __init__(self, api, device_data: dict):
+    def __init__(self, coordinator, device_data: dict):
         """Initialize the sensor entity using device data.
-        
-        :param api: The AirzoneAPI instance to use for updates.
+
+        :param coordinator: The DataUpdateCoordinator instance.
         :param device_data: Dictionary with device information.
         """
-        self._api = api
+        self.coordinator = coordinator
         self._device_data = device_data
         # Construct sensor name: "<Device Name> Temperature"
         name = f"{device_data.get('name', 'Airzone Device')} Temperature"
         self._attr_name = name
 
-        # Use the device 'id' to form a unique id; fallback to a hash of the name if not available.
+        # Use the device 'id' to form a unique id; if missing, fallback to a hash of the name.
         device_id = device_data.get("id")
         if device_id and device_id.strip():
             self._attr_unique_id = f"{device_id}_temperature"
         else:
             self._attr_unique_id = hashlib.sha256(name.encode("utf-8")).hexdigest()
 
-        # Set the unit attributes explicitly for Home Assistant statistics.
+        # Set the unit attributes explicitly for HA statistics and display.
         self._attr_unit_of_measurement = UnitOfTemperature.CELSIUS
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
+        # Set device class and state class for statistics
         self._attr_device_class = "temperature"
         self._attr_state_class = "measurement"
         self._attr_icon = "mdi:thermometer"
+        # Initialize sensor state
         self.update_state()
 
     @property
@@ -73,15 +70,14 @@ class AirzoneTemperatureSensor(SensorEntity):
 
     @property
     def accuracy_decimals(self):
-        """Return the number of decimals to use for the sensor state."""
-        # This ensures that the state is displayed as an integer.
+        """Return the number of decimals to use for the sensor state (display as integer)."""
         return 0
 
     @property
     def device_info(self):
         """Return device info to link this sensor to a device in Home Assistant."""
         return {
-            "identifiers": {("airzoneclouddaikin", self._device_data.get("id"))},
+            "identifiers": { (DOMAIN, self._device_data.get("id")) },
             "name": self._device_data.get("name"),
             "manufacturer": "Daikin",
             "model": self._device_data.get("brand", "Unknown"),
@@ -89,27 +85,18 @@ class AirzoneTemperatureSensor(SensorEntity):
         }
 
     async def async_update(self):
-        """Update the sensor state from the API.
-        
-        This method calls the API (via self._api) to fetch the latest device data
-        for the sensor's device (using its installation_id and id), updates the internal
-        device data, and then updates the sensor state.
+        """Update the sensor state from the coordinator data.
+
+        This method requests a refresh of the coordinator data and then updates
+        the sensor state using the latest device data.
         """
-        installation_id = self._device_data.get("installation_id")
-        device_id = self._device_data.get("id")
-        if not installation_id or not device_id:
-            _LOGGER.error("Missing installation_id or device id in sensor update.")
-            return
-
-        # Fetch the latest device data for the given installation.
-        devices = await self._api.fetch_devices(installation_id)
-        for dev in devices:
-            if dev.get("id") == device_id:
-                self._device_data = dev
-                break
-
+        await self.coordinator.async_request_refresh()
+        # Retrieve the updated device data using the device's unique id
+        device = self.coordinator.data.get(self._device_data.get("id"))
+        if device:
+            self._device_data = device
         self.update_state()
-        self.async_write_ha_state()
+        self.async_schedule_update_ha_state()
 
     def update_state(self):
         """Update the native value from device data."""

--- a/custom_components/airzoneclouddaikin/switch.py
+++ b/custom_components/airzoneclouddaikin/switch.py
@@ -57,14 +57,15 @@ class AirzonePowerSwitch(SwitchEntity):
     async def async_turn_on(self, **kwargs):
         """Turn on the device by sending P1=1 and update state."""
         await self.hass.async_add_executor_job(self.turn_on)
+        # Update device data locally
         self._device_data["power"] = "1"
-        # Do not call async_write_ha_state() here; HA will update automatically
+        # HA will update the state after coordinator refresh
 
     async def async_turn_off(self, **kwargs):
         """Turn off the device by sending P1=0 and update state."""
         await self.hass.async_add_executor_job(self.turn_off)
         self._device_data["power"] = "0"
-        # Do not call async_write_ha_state() here; HA will update automatically
+        # HA will update the state after coordinator refresh
 
     def turn_on(self):
         """Turn on the device."""
@@ -98,5 +99,4 @@ class AirzonePowerSwitch(SwitchEntity):
         device = self.coordinator.data.get(self._device_data.get("id"))
         if device:
             self._device_data = device
-            self._device_data["power"] = str(device.get("power", "0"))
-        # Do not call async_write_ha_state() here; HA will handle it after the coordinator refresh.
+        # HA will update the state automatically after coordinator refresh

--- a/custom_components/airzoneclouddaikin/switch.py
+++ b/custom_components/airzoneclouddaikin/switch.py
@@ -58,13 +58,13 @@ class AirzonePowerSwitch(SwitchEntity):
         """Turn on the device by sending P1=1 and update state."""
         await self.hass.async_add_executor_job(self.turn_on)
         self._device_data["power"] = "1"
-        self.async_write_ha_state()
+        # Do not call async_write_ha_state() here; HA will update automatically
 
     async def async_turn_off(self, **kwargs):
         """Turn off the device by sending P1=0 and update state."""
         await self.hass.async_add_executor_job(self.turn_off)
         self._device_data["power"] = "0"
-        self.async_write_ha_state()
+        # Do not call async_write_ha_state() here; HA will update automatically
 
     def turn_on(self):
         """Turn on the device."""
@@ -86,7 +86,6 @@ class AirzonePowerSwitch(SwitchEntity):
         }
         _LOGGER.info("Sending power command: %s", payload)
         if self.hass and self.hass.loop:
-            # Use the API from the coordinator stored in hass.data
             asyncio.run_coroutine_threadsafe(
                 self.coordinator.api.send_event(payload), self.hass.loop
             )
@@ -99,6 +98,5 @@ class AirzonePowerSwitch(SwitchEntity):
         device = self.coordinator.data.get(self._device_data.get("id"))
         if device:
             self._device_data = device
-            # Update state based on the 'power' field
             self._device_data["power"] = str(device.get("power", "0"))
-        self.async_write_ha_state()
+        # Do not call async_write_ha_state() here; HA will handle it after the coordinator refresh.

--- a/custom_components/airzoneclouddaikin/switch.py
+++ b/custom_components/airzoneclouddaikin/switch.py
@@ -4,83 +4,67 @@ import hashlib
 import logging
 from homeassistant.components.switch import SwitchEntity
 from .const import DOMAIN
-from .airzone_api import AirzoneAPI
 
 _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    """Set up the switch platform from a config entry."""
+    """Set up the switch platform from a config entry using the DataUpdateCoordinator."""
     data = hass.data[DOMAIN].get(entry.entry_id)
     if not data:
         _LOGGER.error("No data found in hass.data for entry %s", entry.entry_id)
         return
     coordinator = data.get("coordinator")
-    config = entry.data
     switches = []
-    # Create a switch entity for each device in coordinator data.
+    # Create a switch entity for each device in the coordinator data.
     for device_id, device in coordinator.data.items():
-        switches.append(AirzonePowerSwitch(coordinator, device, config, hass))
+        switches.append(AirzonePowerSwitch(coordinator, device))
     async_add_entities(switches, True)
 
 class AirzonePowerSwitch(SwitchEntity):
     """Representation of a power switch for an Airzone device."""
 
-    def __init__(self, coordinator, device_data: dict, config: dict, hass):
-        """Initialize the power switch."""
+    def __init__(self, coordinator, device_data: dict):
+        """Initialize the power switch.
+
+        :param coordinator: The DataUpdateCoordinator instance.
+        :param device_data: Dictionary with device information.
+        """
         self.coordinator = coordinator
         self._device_data = device_data
-        self._config = config
-        self._name = f"{device_data.get('name', 'Airzone Device')} Power"
-        self._device_id = device_data.get("id")
-        self._installation_id = device_data.get("installation_id")
-        self._state = bool(int(device_data.get("power", 0)))
-        self.hass = hass
-
-        # Assign unique_id using the device id.
-        if self._device_id:
-            self._attr_unique_id = f"{self._device_id}_power"
+        name = f"{device_data.get('name', 'Airzone Device')} Power"
+        self._attr_name = name
+        device_id = device_data.get("id")
+        if device_id and device_id.strip():
+            self._attr_unique_id = f"{device_id}_power"
         else:
-            _LOGGER.warning("No device ID found; generating unique_id from name.")
-            self._attr_unique_id = hashlib.sha256(self._name.encode("utf-8")).hexdigest()
-
-        self._attr_name = self._name
-
-    @property
-    def unique_id(self):
-        """Return a unique ID for this switch."""
-        return self._attr_unique_id
-
-    @property
-    def name(self):
-        """Return the name of the switch."""
-        return self._attr_name
+            self._attr_unique_id = hashlib.sha256(name.encode("utf-8")).hexdigest()
 
     @property
     def is_on(self):
         """Return True if the device is on."""
-        return self._state
+        return self._device_data.get("power", "0") == "1"
 
     @property
     def device_info(self):
-        """Return device info to link this switch with other entities in HA."""
+        """Return device info to link this switch with other entities in Home Assistant."""
         return {
-            "identifiers": {(DOMAIN, self._device_id)},
+            "identifiers": {(DOMAIN, self._device_data.get("id"))},
             "name": self._device_data.get("name"),
             "manufacturer": self._device_data.get("brand", "Daikin"),
             "model": self._device_data.get("firmware", "Unknown"),
         }
 
     async def async_turn_on(self, **kwargs):
-        """Turn on the device by sending P1=1 and schedule an update."""
+        """Turn on the device by sending P1=1 and update state."""
         await self.hass.async_add_executor_job(self.turn_on)
-        self._state = True
-        self.async_schedule_update_ha_state()
+        self._device_data["power"] = "1"
+        self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
-        """Turn off the device by sending P1=0 and schedule an update."""
+        """Turn off the device by sending P1=0 and update state."""
         await self.hass.async_add_executor_job(self.turn_off)
-        self._state = False
-        self.async_schedule_update_ha_state()
+        self._device_data["power"] = "0"
+        self.async_write_ha_state()
 
     def turn_on(self):
         """Turn on the device."""
@@ -95,23 +79,26 @@ class AirzonePowerSwitch(SwitchEntity):
         payload = {
             "event": {
                 "cgi": "modmaquina",
-                "device_id": self._device_id,
+                "device_id": self._device_data.get("id"),
                 "option": option,
                 "value": value,
             }
         }
         _LOGGER.info("Sending power command: %s", payload)
         if self.hass and self.hass.loop:
-            asyncio.run_coroutine_threadsafe(self._api.send_event(payload), self.hass.loop)
+            # Use the API from the coordinator stored in hass.data
+            asyncio.run_coroutine_threadsafe(
+                self.coordinator.api.send_event(payload), self.hass.loop
+            )
         else:
             _LOGGER.error("No hass loop available; cannot send command.")
 
     async def async_update(self):
-        """Update the switch state by reading from the coordinator data."""
+        """Update the switch state from the coordinator data."""
         await self.coordinator.async_request_refresh()
-        device = self.coordinator.data.get(self._device_id)
+        device = self.coordinator.data.get(self._device_data.get("id"))
         if device:
             self._device_data = device
-            self._state = bool(int(device.get("power", 0)))
-            _LOGGER.info("Power state updated: %s", self._state)
-        self.async_schedule_update_ha_state()
+            # Update state based on the 'power' field
+            self._device_data["power"] = str(device.get("power", "0"))
+        self.async_write_ha_state()

--- a/custom_components/airzoneclouddaikin/switch.py
+++ b/custom_components/airzoneclouddaikin/switch.py
@@ -10,33 +10,24 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up the switch platform from a config entry."""
-    config = entry.data
-    from homeassistant.helpers.aiohttp_client import async_get_clientsession
-    session = async_get_clientsession(hass)
-    api = AirzoneAPI(config.get("username"), config.get("password"), session)
-    if not await api.login():
-        _LOGGER.error("Login to Airzone API failed in switch setup.")
+    data = hass.data[DOMAIN].get(entry.entry_id)
+    if not data:
+        _LOGGER.error("No data found in hass.data for entry %s", entry.entry_id)
         return
-    installations = await api.fetch_installations()
+    coordinator = data.get("coordinator")
+    config = entry.data
     switches = []
-    for relation in installations:
-        installation = relation.get("installation")
-        if not installation:
-            continue
-        installation_id = installation.get("id")
-        if not installation_id:
-            continue
-        devices = await api.fetch_devices(installation_id)
-        for device in devices:
-            switches.append(AirzonePowerSwitch(api, device, config, hass))
+    # Create a switch entity for each device in coordinator data.
+    for device_id, device in coordinator.data.items():
+        switches.append(AirzonePowerSwitch(coordinator, device, config, hass))
     async_add_entities(switches, True)
 
 class AirzonePowerSwitch(SwitchEntity):
     """Representation of a power switch for an Airzone device."""
 
-    def __init__(self, api: AirzoneAPI, device_data: dict, config: dict, hass):
+    def __init__(self, coordinator, device_data: dict, config: dict, hass):
         """Initialize the power switch."""
-        self._api = api
+        self.coordinator = coordinator
         self._device_data = device_data
         self._config = config
         self._name = f"{device_data.get('name', 'Airzone Device')} Power"
@@ -44,7 +35,6 @@ class AirzonePowerSwitch(SwitchEntity):
         self._installation_id = device_data.get("installation_id")
         self._state = bool(int(device_data.get("power", 0)))
         self.hass = hass
-        self._hass_loop = hass.loop
 
         # Assign unique_id using the device id.
         if self._device_id:
@@ -54,8 +44,6 @@ class AirzonePowerSwitch(SwitchEntity):
             self._attr_unique_id = hashlib.sha256(self._name.encode("utf-8")).hexdigest()
 
         self._attr_name = self._name
-        # Explicitly set entity_id for HA 2025.3 compatibility.
-        self.entity_id = f"switch.{self._attr_unique_id}"
 
     @property
     def unique_id(self):
@@ -86,13 +74,13 @@ class AirzonePowerSwitch(SwitchEntity):
         """Turn on the device by sending P1=1 and schedule an update."""
         await self.hass.async_add_executor_job(self.turn_on)
         self._state = True
-        self.schedule_update_ha_state()  # Ensure HA reflects the change immediately
+        self.async_schedule_update_ha_state()
 
     async def async_turn_off(self, **kwargs):
         """Turn off the device by sending P1=0 and schedule an update."""
         await self.hass.async_add_executor_job(self.turn_off)
         self._state = False
-        self.schedule_update_ha_state()  # Ensure HA reflects the change immediately
+        self.async_schedule_update_ha_state()
 
     def turn_on(self):
         """Turn on the device."""
@@ -113,26 +101,17 @@ class AirzonePowerSwitch(SwitchEntity):
             }
         }
         _LOGGER.info("Sending power command: %s", payload)
-        if self._hass_loop:
-            asyncio.run_coroutine_threadsafe(self._api.send_event(payload), self._hass_loop)
+        if self.hass and self.hass.loop:
+            asyncio.run_coroutine_threadsafe(self._api.send_event(payload), self.hass.loop)
         else:
             _LOGGER.error("No hass loop available; cannot send command.")
 
     async def async_update(self):
-        """Update the switch state by polling the device status from the API."""
-        if not self._installation_id:
-            _LOGGER.error("No installation id available for device %s", self._device_id)
-            return
-
-        installations = await self._api.fetch_installations()
-        for relation in installations:
-            installation = relation.get("installation")
-            if installation and installation.get("id") == self._installation_id:
-                devices = await self._api.fetch_devices(self._installation_id)
-                for dev in devices:
-                    if dev.get("id") == self._device_id:
-                        self._device_data = dev
-                        self._state = bool(int(dev.get("power", 0)))
-                        _LOGGER.info("Power state updated: %s", self._state)
-                        self.schedule_update_ha_state()  # Ensure HA updates the entity state
-                        break
+        """Update the switch state by reading from the coordinator data."""
+        await self.coordinator.async_request_refresh()
+        device = self.coordinator.data.get(self._device_id)
+        if device:
+            self._device_data = device
+            self._state = bool(int(device.get("power", 0)))
+            _LOGGER.info("Power state updated: %s", self._state)
+        self.async_schedule_update_ha_state()


### PR DESCRIPTION
[0.2.8] - 2025-04-09
Fixed

    Compatibility with Home Assistant 2025.4+:

        Resolved critical errors caused by TypeError: argument of type 'int' is not iterable in climate.py when evaluating supported features.

        Removed unsupported checks like if ClimateEntityFeature.X in supported_features, replacing them with bitwise operations to avoid compatibility issues with bitmask flags.

        Eliminated invalid imports such as ATTR_MIN_TEMP and ATTR_MAX_TEMP from homeassistant.const (now imported from homeassistant.components.climate).

Changed

    Climate Entity (climate.py):

        Now hides fan controls (fan mode and fan speeds) when HVAC mode is OFF or DRY.

        Updated fan_modes and fan_mode properties to return empty list or None when fan control is not applicable.

        The supported_features property dynamically adjusts the capabilities based on the current HVAC mode, removing temperature and fan control when in unsupported modes (OFF, DRY, or FAN_ONLY).

        Improved capability_attributes to conditionally expose supported capabilities, avoiding crashes in Home Assistant core when rendering UI elements.

        Removed unnecessary overrides and obsolete code that caused entity registration failures (NoEntitySpecifiedError and AttributeError: __attr_hvac_mode).

Improved

    Codebase Maintenance:

        Refactored legacy entity attribute assignments to fully comply with Home Assistant’s internal attribute naming conventions.

        Ensured all inline comments are in English for consistency across the repository.

        Eliminated the use of async_write_ha_state() or thread-safe update calls that conflicted with Home Assistant's async context in 2025.4 and beyond.

        Improved fault tolerance in set_temperature() and set_fan_speed() by preventing unsupported operations in certain modes with clear warnings in the logs.

Notes

    This version ensures full compatibility with Home Assistant 2025.4+, especially regarding the updated behavior of ClimateEntityFeature and entity lifecycle handling.

    The fan control now gracefully disappears in modes where it’s not applicable (DRY, OFF), improving UI clarity and preventing invalid operations.

    Restart Home Assistant after updating to ensure all entity states and services are reloaded correctly.