### PR TITLE
Align offline threshold constant and purge API passwords

### DIFF
--- a/custom_components/airzoneclouddaikin/__init__.py
+++ b/custom_components/airzoneclouddaikin/__init__.py
@@ -31,6 +31,7 @@ from homeassistant.util import dt as dt_util
 from .airzone_api import AirzoneAPI
 from .const import (
     DOMAIN,
+    INTERNAL_STALE_AFTER_SEC,
     OFFLINE_DEBOUNCE_SEC,
     ONLINE_BANNER_TTL_SEC,
     PN_KEY_PREFIX,
@@ -41,8 +42,7 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_SCAN_INTERVAL_SEC = 10
-# Fixed stale threshold for connectivity (minutes).
-OFFLINE_STALE_MINUTES = 10
+_OFFLINE_STALE_SECONDS = int(INTERNAL_STALE_AFTER_SEC)
 
 _BASE_PLATFORMS: list[str] = ["climate", "sensor", "switch", "binary_sensor"]
 _EXTRA_PLATFORMS: list[str] = ["number"]  # keep number for now
@@ -156,7 +156,7 @@ def _is_online(dev: dict[str, Any], now: datetime) -> bool:
         return True
     dt = dt_util.as_utc(dt)
     age = (now - dt).total_seconds()
-    return age <= OFFLINE_STALE_MINUTES * 60
+    return age <= _OFFLINE_STALE_SECONDS
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/airzoneclouddaikin/airzone_api.py
+++ b/custom_components/airzoneclouddaikin/airzone_api.py
@@ -97,6 +97,20 @@ class AirzoneAPI:
         """Update auth token for subsequent requests."""
         self._token = token
 
+    @property
+    def password(self) -> str | None:
+        """Expose the current password in memory (if any)."""
+        return self._password
+
+    @password.setter
+    def password(self, value: str | None) -> None:
+        """Update the stored password (used for hygiene in config flow)."""
+        self._password = value
+
+    def clear_password(self) -> None:
+        """Explicit helper to purge the password from memory."""
+        self._password = None
+
     # --------------------------
     # Helpers
     # --------------------------

--- a/custom_components/airzoneclouddaikin/config_flow.py
+++ b/custom_components/airzoneclouddaikin/config_flow.py
@@ -130,7 +130,7 @@ class AirzoneConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         finally:
             # Shorten lifetime of password in memory
             try:
-                api.password = None
+                api.clear_password()
             except Exception:  # noqa: BLE001
                 pass
 
@@ -211,7 +211,7 @@ class AirzoneConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
         finally:
             try:
-                api.password = None
+                api.clear_password()
             except Exception:  # noqa: BLE001
                 pass
 

--- a/custom_components/airzoneclouddaikin/number.py
+++ b/custom_components/airzoneclouddaikin/number.py
@@ -175,10 +175,10 @@ class _BaseDKNNumber(CoordinatorEntity[AirzoneCoordinator], NumberEntity):
         if current is not None and current == ivalue:
             return
 
+        payload = {"device": {self._field_name: ivalue}}
+
         try:
-            await self._api.put_device_fields(
-                self._device_id, {self._field_name: ivalue}
-            )
+            await self._api.put_device_fields(self._device_id, payload)
         except asyncio.CancelledError:
             raise
         except Exception:


### PR DESCRIPTION
## Summary
- derive the coordinator's offline threshold from `INTERNAL_STALE_AFTER_SEC` so connectivity logic shares a single source of truth
- wrap number-entity writes in the expected `{"device": ...}` payload before calling `put_device_fields`
- add an explicit password clearer on `AirzoneAPI` and use it in the config flow to drop secrets from memory

## Testing
- python -m compileall custom_components/airzoneclouddaikin

------
https://chatgpt.com/codex/tasks/task_e_69061cd826948324bac5e958642cefec