### PR TITLE
Document connectivity threshold and API payload fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.4.0 - RC3] - 2025-11-01
+### Fixed
+- Align the coordinator offline detection helper with `INTERNAL_STALE_AFTER_SEC` so binary sensors and notifications rely on the same 10-minute threshold.
+- Wrap number-entity writes in the expected `{"device": ...}` envelope to satisfy the `/devices/<id>` API contract.
+- Purge passwords from memory immediately after login/reauth via the new `AirzoneAPI.clear_password()` helper and config flow usage.
+
+### Docs
+- README: document the fixed offline threshold/debounce used for connectivity checks and notifications.
+- info.md: clarify that device field updates (`sleep_time`, unoccupied limits) must be sent inside the `{"device": {...}}` payload.
+
 ## [0.4.0 - RC2] - 2025-11-01
 ### Tooling
 - Bump **Python floor to 3.14** for development and CI (format/lint). Set `requires-python = ">=3.14.0"` and update Black/Ruff `target-version` to `py314`.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Optimized for the "DAIKIN ES.DKNWSERVER Wi-Fi adapter" — climate, fan, diagnos
 
 - The integration exposes `sensor.<id>_last_connection` (timestamp, enabled by default) and `binary_sensor.<id>_wserver_online` (connectivity, enabled by default).
 - Online/offline is derived **passively** from the age of `connection_date` (no extra pings).
-- Option `stale_after_minutes` (default **10**) controls the threshold before considering the device offline.
+- Offline detection uses a fixed **10-minute** internal threshold with a **90 s** debounce shared between connectivity sensors and persistent notifications.
 - When a control request fails with HTTP **422**, Home Assistant shows: **“DKN WServer not connected (422)”**.
 
 ---

--- a/custom_components/airzoneclouddaikin/__init__.py
+++ b/custom_components/airzoneclouddaikin/__init__.py
@@ -31,6 +31,7 @@ from homeassistant.util import dt as dt_util
 from .airzone_api import AirzoneAPI
 from .const import (
     DOMAIN,
+    INTERNAL_STALE_AFTER_SEC,
     OFFLINE_DEBOUNCE_SEC,
     ONLINE_BANNER_TTL_SEC,
     PN_KEY_PREFIX,
@@ -41,8 +42,7 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_SCAN_INTERVAL_SEC = 10
-# Fixed stale threshold for connectivity (minutes).
-OFFLINE_STALE_MINUTES = 10
+_OFFLINE_STALE_SECONDS = int(INTERNAL_STALE_AFTER_SEC)
 
 _BASE_PLATFORMS: list[str] = ["climate", "sensor", "switch", "binary_sensor"]
 _EXTRA_PLATFORMS: list[str] = ["number"]  # keep number for now
@@ -156,7 +156,7 @@ def _is_online(dev: dict[str, Any], now: datetime) -> bool:
         return True
     dt = dt_util.as_utc(dt)
     age = (now - dt).total_seconds()
-    return age <= OFFLINE_STALE_MINUTES * 60
+    return age <= _OFFLINE_STALE_SECONDS
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/airzoneclouddaikin/airzone_api.py
+++ b/custom_components/airzoneclouddaikin/airzone_api.py
@@ -97,6 +97,20 @@ class AirzoneAPI:
         """Update auth token for subsequent requests."""
         self._token = token
 
+    @property
+    def password(self) -> str | None:
+        """Expose the current password in memory (if any)."""
+        return self._password
+
+    @password.setter
+    def password(self, value: str | None) -> None:
+        """Update the stored password (used for hygiene in config flow)."""
+        self._password = value
+
+    def clear_password(self) -> None:
+        """Explicit helper to purge the password from memory."""
+        self._password = None
+
     # --------------------------
     # Helpers
     # --------------------------

--- a/custom_components/airzoneclouddaikin/config_flow.py
+++ b/custom_components/airzoneclouddaikin/config_flow.py
@@ -130,7 +130,7 @@ class AirzoneConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         finally:
             # Shorten lifetime of password in memory
             try:
-                api.password = None
+                api.clear_password()
             except Exception:  # noqa: BLE001
                 pass
 
@@ -211,7 +211,7 @@ class AirzoneConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
         finally:
             try:
-                api.password = None
+                api.clear_password()
             except Exception:  # noqa: BLE001
                 pass
 

--- a/custom_components/airzoneclouddaikin/number.py
+++ b/custom_components/airzoneclouddaikin/number.py
@@ -175,10 +175,10 @@ class _BaseDKNNumber(CoordinatorEntity[AirzoneCoordinator], NumberEntity):
         if current is not None and current == ivalue:
             return
 
+        payload = {"device": {self._field_name: ivalue}}
+
         try:
-            await self._api.put_device_fields(
-                self._device_id, {self._field_name: ivalue}
-            )
+            await self._api.put_device_fields(self._device_id, payload)
         except asyncio.CancelledError:
             raise
         except Exception:

--- a/info.md
+++ b/info.md
@@ -162,14 +162,15 @@ Devices expose a **string** bitmask for 8 modes, **index-aligned with P2**:
 
 - **Scene (`scenary`)**: `"occupied" | "vacant" | "sleep"`  
   - Update via: `PUT /devices/<id>` with body `{"device":{"scenary":"occupied"}}`
-- **Sleep (`sleep_time`)**: minutes in **[30..120]**, **step 10**.  
-  - Update via: `PUT /devices/<id>` with body `{"sleep_time":60}`
+- **Sleep (`sleep_time`)**: minutes in **[30..120]**, **step 10**.
+  - Update via: `PUT /devices/<id>` with body `{"device":{"sleep_time":60}}`
 
 ### Unoccupied limits (when provided by the backend)
 Two device fields may appear and can be updated via **root-level** PUT on `/devices/<id>`:
 
 - `min_temp_unoccupied` (**HEAT** minimum): **12..22 °C**, step **1**
 - `max_temp_unoccupied` (**COOL** maximum): **24..34 °C**, step **1**
+  - Send updates inside the device wrapper, e.g. `{"device":{"min_temp_unoccupied":18}}` (you may combine multiple fields).
 
 **Occupied switching note:** When sending control events (power/mode/speed/setpoint), the backend **often switches** a `vacant` device to `occupied`. The integration **does not force** `occupied` proactively. We **refresh** after commands; if a specific installation requires it, a **config option** may force `scenary="occupied"` (with a short cooldown).
 


### PR DESCRIPTION
## Summary
- add a 0.4.0 RC3 changelog entry covering the offline threshold, number payload, and password hygiene fixes
- update the README connectivity section to describe the fixed 10-minute threshold and shared debounce
- clarify in info.md that device writes for sleep/unoccupied limits must use the `{ "device": { ... } }` payload wrapper

## Testing
- python -m compileall custom_components/airzoneclouddaikin

------
https://chatgpt.com/codex/tasks/task_e_69061cd826948324bac5e958642cefec