### PR TITLE
Improve preset diagnostic sensor handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.1a7] - 2025-11-20
+### Added
+- Added diagnostic sensor `preset_mode` to expose the current scenary as a history-friendly preset value (`home/away/sleep`).
+
 ## [0.4.1a6] - 2025-11-20
 ### Fixed
 - Guard config entry unload cleanup behind bucket existence checks so missing buckets no longer raise, ensuring cleanup only runs when the entry data is present.

--- a/custom_components/airzoneclouddaikin/manifest.json
+++ b/custom_components/airzoneclouddaikin/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://github.com/eXPerience83/DKNCloud-HASS",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/eXPerience83/DKNCloud-HASS/issues",
-  "version": "0.4.1a6"
+  "version": "0.4.1a7"
 }

--- a/custom_components/airzoneclouddaikin/sensor.py
+++ b/custom_components/airzoneclouddaikin/sensor.py
@@ -102,6 +102,7 @@ CORE_SENSORS: list[tuple[str, str, str, bool, str | None, str | None]] = [
 DIAG_SENSORS: list[tuple[str, str, str, bool, str | None, str | None]] = [
     ("progs_enabled", "Programs Enabled", "mdi:calendar-check", True, None, None),
     ("power", "Power State (Raw)", "mdi:power", True, None, None),
+    ("preset_mode", "Preset Mode", "mdi:home-switch", True, None, None),
     ("units", "Units", "mdi:ruler", False, None, None),
     (
         "min_temp_unoccupied",
@@ -470,6 +471,18 @@ class AirzoneSensor(CoordinatorEntity[AirzoneCoordinator], SensorEntity):
 
         if self._attribute == "heat_cool_supported":
             return device_supports_heat_cool(self._device)
+
+        if self._attribute == "preset_mode":
+            scen = str(self._device.get("scenary") or "").strip().lower()
+            if not scen:
+                return None
+
+            mapping = {
+                "occupied": "home",
+                "vacant": "away",
+                "sleep": "sleep",
+            }
+            return mapping.get(scen, scen)
 
         # Whether fan modes are normalized (low/medium/high) or numeric (1..N)
         if self._attribute == "fan_modes_normalized":


### PR DESCRIPTION
### **User description**
## Summary
- allow the preset diagnostic sensor to fall back to the raw scenary value while reporting unknown when empty
- document the new preset diagnostic sensor in the changelog and bump the version to 0.4.1a7

## Testing
- ruff check --fix --select I
- ruff check
- black .

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691eb3fcf7088324a4fdf1c65884168f)


___

### **PR Type**
Enhancement


___

### **Description**
- Add new diagnostic sensor `preset_mode` for scenary mapping

- Map raw scenary values to preset modes (home/away/sleep)

- Return None when scenary is empty or missing

- Update version to 0.4.1a7 and document changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Raw scenary value"] -->|"strip & lowercase"| B["Check if empty"]
  B -->|"not empty"| C["Map to preset mode"]
  C -->|"home/away/sleep"| D["Return mapped value"]
  B -->|"empty"| E["Return None"]
  C -->|"unknown value"| F["Return raw value"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sensor.py</strong><dd><code>Add preset mode diagnostic sensor implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/airzoneclouddaikin/sensor.py

<ul><li>Added <code>preset_mode</code> diagnostic sensor to <code>DIAG_SENSORS</code> list<br> <li> Implemented mapping logic in <code>native_value()</code> method to convert scenary <br>values to preset modes<br> <li> Maps "occupied" → "home", "vacant" → "away", "sleep" → "sleep"<br> <li> Returns None when scenary is empty, otherwise returns mapped or raw <br>value</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/25/files#diff-181e48773c8839173b812b3c8fe3fd77414c465e7a783bd35b408b089ce6dfab">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document preset mode sensor addition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added new version section [0.4.1a7] with date 2025-11-20<br> <li> Documented the new <code>preset_mode</code> diagnostic sensor feature<br> <li> Explained that it exposes scenary as history-friendly preset values</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/25/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Bump version to 0.4.1a7</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/airzoneclouddaikin/manifest.json

- Bumped version from 0.4.1a6 to 0.4.1a7


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/25/files#diff-d7d310fbf33b630263734ddd50b73aa9908a7b336222ea7c340cf745a421e512">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

