### PR TITLE
Clarify setup docstring and bump release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.4.1a10] - 2025-11-23
+### Changed
+- Clarify the config entry setup docstring now that migrations are handled separately.
+- Bump integration version metadata to keep documentation and manifest aligned.
+
+## [0.4.1a9] - 2025-11-22
+### Fixed
+- Normalize the username for every redisplayed config form to remove whitespace-only input and keep defaults consistent across all error cases.
+- Validate missing or empty passwords defensively before attempting login to avoid unnecessary API calls and potential KeyErrors during tests.
+- Keep the config flow input handling aligned with Home Assistant naming conventions and document the shallow copy used to normalize form defaults.
+
 ## [0.4.1a8] - 2025-11-21
 ### Fixed
 - Reject empty or whitespace-only emails in the config flow before assigning unique IDs or attempting login, preventing invalid identifiers and unnecessary API calls.

--- a/custom_components/airzoneclouddaikin/__init__.py
+++ b/custom_components/airzoneclouddaikin/__init__.py
@@ -266,7 +266,7 @@ def _is_online(dev: dict[str, Any], now: datetime) -> bool:
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up DKN Cloud for HASS from a config entry (no migrations)."""
+    """Set up DKN Cloud for HASS from a config entry."""
     hass.data.setdefault(DOMAIN, {})
     cfg = entry.data
     opts = entry.options

--- a/custom_components/airzoneclouddaikin/config_flow.py
+++ b/custom_components/airzoneclouddaikin/config_flow.py
@@ -96,8 +96,20 @@ class AirzoneConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 step_id="user", data_schema=_user_schema({}), errors={}
             )
 
+        # Work on a shallow copy so we can normalize fields used as form defaults
+        user_input = dict(user_input)
+
         email = str(user_input.get(CONF_USERNAME, "")).strip()
+        user_input[CONF_USERNAME] = email
         if not email:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=_user_schema(user_input),
+                errors={"base": "invalid_auth"},
+            )
+
+        password = str(user_input.get(CONF_PASSWORD, ""))
+        if not password:
             return self.async_show_form(
                 step_id="user",
                 data_schema=_user_schema(user_input),
@@ -107,7 +119,6 @@ class AirzoneConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         normalized_email = email.casefold()
         await self.async_set_unique_id(normalized_email)
         self._abort_if_unique_id_configured()
-        password = str(user_input[CONF_PASSWORD])
         scan = int(user_input.get(CONF_SCAN_INTERVAL, 10))
         pii = bool(user_input.get(CONF_EXPOSE_PII, False))
 

--- a/custom_components/airzoneclouddaikin/manifest.json
+++ b/custom_components/airzoneclouddaikin/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://github.com/eXPerience83/DKNCloud-HASS",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/eXPerience83/DKNCloud-HASS/issues",
-  "version": "0.4.1a8"
+  "version": "0.4.1a10"
 }


### PR DESCRIPTION
### **User description**
## Summary
- Clarify the config entry setup docstring to reflect current migration handling.
- Bump the changelog and manifest to version 0.4.1a10 to keep metadata aligned.

## Testing
- black custom_components/airzoneclouddaikin/__init__.py
- ruff check --fix --select I custom_components/airzoneclouddaikin/__init__.py
- ruff check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920086ab81c8324840966497b474dde)


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Clarify setup docstring by removing outdated migration reference

- Add defensive password validation in config flow

- Normalize username input with shallow copy for consistency

- Bump version to 0.4.1a10 and update changelog


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Config Flow Input"] -->|"Shallow Copy"| B["Normalize Username"]
  B -->|"Validate Email"| C["Check Password"]
  C -->|"Valid"| D["Create Entry"]
  C -->|"Invalid"| E["Show Error Form"]
  F["Setup Docstring"] -->|"Remove Migration Note"| G["Clarified Documentation"]
  H["Version 0.4.1a8"] -->|"Bump to"| I["Version 0.4.1a10"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Clarify setup entry docstring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/airzoneclouddaikin/__init__.py

<ul><li>Simplify <code>async_setup_entry</code> docstring by removing outdated "(no <br>migrations)" note<br> <li> Reflect current migration handling approach in documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/27/files#diff-0a2b04957b431594d35fbd3d53311cac51b252756aa7ecc03da2d3954c05aa56">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog with recent improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Add version 0.4.1a10 entry documenting docstring clarification and <br>version bump<br> <li> Add version 0.4.1a9 entry detailing username normalization and <br>password validation improvements<br> <li> Document shallow copy usage and defensive validation patterns</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/27/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config_flow.py</strong><dd><code>Add password validation and input normalization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/airzoneclouddaikin/config_flow.py

<ul><li>Create shallow copy of user input for safe normalization of form <br>defaults<br> <li> Add explicit password validation before attempting login to prevent <br>KeyErrors<br> <li> Normalize and store username early in flow for consistent form <br>redisplay<br> <li> Move password extraction after validation for defensive error handling</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/27/files#diff-70f229c9e2bc68445d071d80f4be1733b1d2b6d833c5c1c79e0fba3cedf86f9f">+12/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Bump integration version to 0.4.1a10</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/airzoneclouddaikin/manifest.json

<ul><li>Bump version from 0.4.1a8 to 0.4.1a10<br> <li> Keep manifest aligned with changelog and code changes</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/27/files#diff-d7d310fbf33b630263734ddd50b73aa9908a7b336222ea7c340cf745a421e512">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

