### PR TITLE
Consolidate empty credential validation in config flow

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -2,6 +2,7 @@ name: Validate with hassfest
 
 on:
   push:
+    branches: [main, master]
   pull_request:
   schedule:
     - cron: "0 0 * * *"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,7 @@ name: Lint
 
 on:
   push:
+    branches: [main, master]
   pull_request:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,6 +2,7 @@ name: Validate with HACS
 
 on:
   push:
+    branches: [main, master]
   pull_request:
   schedule:
     - cron: "0 0 * * *"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Changelog
+## [0.4.2] - 2025-11-24
+### Added
+- Added French, Portuguese, Italian, and German locale files covering configuration flows,
+  options, exceptions, and connectivity notifications.
+- Added a regression test to ensure every translation file mirrors the English keyset so new
+  strings are not left untranslated.
+
+### Changed
+- Updated integration metadata to version 0.4.2.
+
 ## [0.4.1] - 2025-11-24
 ### Added
 - Optional HEAT_COOL (P2=4) exposure in climate entities when the modes bitmask advertises
@@ -16,8 +26,8 @@
   (currently accepted even if not yet officially documented) and keep Ruff aligned.
 - Rename the experimental P2=4 mode to `HVACMode.HEAT_COOL` throughout the integration and ensure
   fan/temperature writes always use the cold path (P7/P3). Historical changelog entries that
-  mentioned “AUTO” refer to this same mode.
-- Document the HEAT_COOL opt-in policy in `info.md`, remove “AUTO” terminology, and surface the
+  referenced the former automatic label refer to this same experimental mode.
+- Document the HEAT_COOL opt-in policy in `info.md`, remove the previous automatic terminology, and surface the
   updated options-flow toggle copy (EN/ES) that calls out the P7/P3 routing.
 - Power switch service now proxies the sibling climate entity for consistent away handling,
   optimistic overlays, and refresh semantics while retaining a direct P1 fallback when the climate
@@ -373,7 +383,8 @@
 - Moved `import time` to module level in `select.py` and `number.py` to avoid per-read imports in
   entity properties and improve async hygiene.
 ### Changed
-- `P2=4 (AUTO)` remains unsupported for now; docs toggle will be added when implemented.
+- `P2=4 (HEAT_COOL)` remains an experimental opt-in; documentation for the toggle will be added
+  when implemented.
 
 ## [0.3.7a11] - 2025-09-27
 ### Changed
@@ -695,8 +706,9 @@
   device was off did not turn it on automatically. - Now, if the HVAC mode is OFF and a new mode is
   set, the system first turns on the device before applying the selected mode.
 ### Changed
-- **Code Refactoring & Consistency**:   - Renamed `HVAC_MODE_AUTO` to `HVACMode.AUTO` for
-  consistency across all files. - Removed unused `set_preset_mode()` function from `climate.py`
+- **Code Refactoring & Consistency**:   - Renamed the legacy automatic mode constant to
+  `HVACMode.HEAT_COOL` for consistency across all files and to reflect the experimental nature of
+  the mode. - Removed unused `set_preset_mode()` function from `climate.py`
   since preset modes are not yet implemented. - Ensured all comments and logs are in English for
   consistency and readability. - Improved error handling and logging for better debugging and
   traceability.
@@ -734,13 +746,14 @@
   of "brand" (e.g. "ADEQ125B2VEB") and is labeled as “Model”.
 - Extended info.md to include details about the “modes” field (binary mapping for P2) and how it
   correlates with standard HVAC modes: - Mapping: P2 "1" → COOL, "2" → HEAT, "3" → FAN ONLY, "4" →
-  AUTO, "5" → DRY; states 6–8 are considered Unavailable.
+  HEAT_COOL (experimental), "5" → DRY; states 6–8 are considered Unavailable.
 - Updated device_info in climate.py to remove unsupported keywords and correctly display device
   attributes.
 - Minor improvements to logging and error handling.
 ### Changed
 - Revised handling of device data updates in climate.py.
-- Adjusted fan speed commands: now using P3 for COOL/FAN_ONLY modes and P4 for HEAT/AUTO modes.
+- Adjusted fan speed commands: now using P3 for COOL/FAN_ONLY modes and P4 for HEAT/HEAT_COOL
+  modes.
 - Removed any references to a forced scan interval; the integration now relies on Home Assistant’s
   built-in polling mechanism.
 - Cleaned up comments and updated documentation to reflect all changes in English.
@@ -758,7 +771,8 @@
   using the device id.
 - Sensor Platform (sensor.py): - Added async_setup_entry so that sensor entities are loaded from the
   config entry.
-- Renamed "heat-cold-auto" to HVACMode.AUTO (module-level constant HVAC_MODE_AUTO) in the code.
+- Renamed "heat-cold-auto" to `HVACMode.HEAT_COOL` (module-level constant
+  `HVAC_MODE_HEAT_COOL`) in the code.
 
 ## [0.2.3] - 2025-03-19
 ### Added
@@ -766,7 +780,8 @@
 - Fixed unique_id for both climate and sensor entities so they are properly registered and managed
   in the Home Assistant UI.
 - Added asynchronous method `send_event` to the AirzoneAPI class in airzone_api.py.
-- Updated config_flow.py to include the "force_hvac_mode_auto" option.
+- Updated config_flow.py to include the "force_heat_cool_mode" option for experimental
+  heat-cold behavior.
 - Updated set_temperature in climate.py to constrain values based on device limits
   (min_limit_cold/max_limit_cold for cool modes; min_limit_heat/max_limit_heat for heat modes) and
   format the value as an integer with ".0".
@@ -776,12 +791,12 @@
 - Replaced deprecated async_forward_entry_setup with async_forward_entry_setups in __init__.py.
 - Updated imports in climate.py and sensor.py to use HVACMode, ClimateEntityFeature, and
   UnitOfTemperature.
-- Renamed "heat-cold-auto" to HVACMode.AUTO in the code.
+- Renamed "heat-cold-auto" to `HVACMode.HEAT_COOL` in the code.
 - Updated README.md with full integration details in English.
 - Updated all text and comments to English.
 ### Changed
 - Further verification of fan speed control in different modes.
-- Additional testing of HVACMode.AUTO behavior on various machine models.
+- Additional testing of `HVACMode.HEAT_COOL` behavior on various machine models.
 
 ## [0.2.2] - 2025-03-19
 ### Added
@@ -789,26 +804,26 @@
 - In the API calls for installations, now includes "user_email" and "user_token" in query
   parameters.
 - Added support for controlling fan speed: - P3 for fan speed in cool (ventilate) mode. - P4 for fan
-  speed in heat/auto mode.
-- Renamed "heat-cold-auto" to HVACMode.AUTO in all code.
+  speed in heat/HEAT_COOL mode.
+- Renamed "heat-cold-auto" to `HVACMode.HEAT_COOL` in all code.
 - In set_temperature, the temperature is now constrained to the limits
   (min_limit_cold/max_limit_cold or min_limit_heat/max_limit_heat) from the API; the value is sent
   as an integer with ".0" appended.
-- Added the configuration option "force_hvac_mode_auto" (in config_flow) to enable the forced auto
-  mode.
+- Added the configuration option "force_heat_cool_mode" (in config_flow) to enable the experimental
+  HEAT_COOL mode.
 - Updated info.md with the original MODES_CONVERTER mapping from max13fr, with a note that only
   modes 1–5 produced effect in our tests (model ADEQ125B2VEB).
 ### Changed
 - Minor adjustments in config_flow.py, climate.py, and README.md.
-- Pending: Verify additional fan speed adjustments for FAN_ONLY and HVACMode.AUTO modes.
+- Pending: Verify additional fan speed adjustments for FAN_ONLY and `HVACMode.HEAT_COOL` modes.
 
 ## [0.2.1] - 2025-03-19
 ### Added
 - Integration updated to version 0.2.1.
-- Added configuration option "force_heat_cold_auto" in config_flow (allows forcing the
-  "heat-cold-auto" mode).
+- Added configuration option "force_heat_cold_auto" in config_flow (allows forcing the experimental
+  HEAT_COOL mode).
 - Updated async_setup_entry in climate.py to pass configuration to each climate entity.
-- In AirzoneClimate (climate.py), the property hvac_modes now includes "heat-cold-auto" if
+- In AirzoneClimate (climate.py), the property hvac_modes now includes HEAT_COOL if
   force_heat_cold_auto is enabled.
 - Added property fan_speed_range in climate.py to dynamically generate the list of valid fan speeds
   from the API field "availables_speeds".
@@ -820,7 +835,7 @@
 ### Changed
 - Version updated in manifest.json to 0.2.1.
 - Minor adjustments in config_flow.py, __init__.py, and README.md.
-- Pending: Verify fan speed adjustment in FAN_ONLY and HVACMode.AUTO modes.
+- Pending: Verify fan speed adjustment in FAN_ONLY and `HVACMode.HEAT_COOL` modes.
 
 ## [0.2.0] - 2025-03-19
 ### Added

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Optimized for the "DAIKIN ES.DKNWSERVER Wi-Fi adapter" — climate, fan, diagnos
 | `"8"`    | FAN_ONLY (fallback)    | Heat-type ventilation fallback (fan commands routed to **P4**). |
 
 > **About HEAT_COOL (API label “heat-cold-auto”)**
-> This mode is **opt-in and experimental**. It appears only when both the device bitmask exposes bit 3 and the new option **Enable experimental HEAT_COOL mode** is enabled. While active, the integration always uses **P7** for the setpoint and **P3** for fan speed.
+> This mode is **opt-in and experimental/beta**. It appears only when both the device bitmask exposes bit 3 and the new option **Enable experimental HEAT_COOL mode** is enabled. While active, the integration always uses **P7** for the setpoint and **P3** for fan speed.
 
 ---
 
@@ -110,6 +110,11 @@ Enter your Airzone Cloud **username** and **password**.
 
 > Full API/command mapping and advanced usage in [info.md](./info.md).
 
+## 🌐 Localizations
+
+- UI strings are localized for **English, Spanish, French, German, Italian, and Portuguese**.
+- Translation coverage tests ensure new strings stay in sync across locales.
+
 ---
 
 ## 📷 Screenshots
@@ -133,7 +138,6 @@ Enter your Airzone Cloud **username** and **password**.
 
 ## 🛣️ Roadmap
 
-- [ ] **Translations (i18n)** — translate 422 and connectivity banners; add locales beyond **EN/ES** (CA/DE/FR/IT/PL/RU/UK…)
 - [ ] **HEAT_COOL (opt-in)** — ongoing validation across devices/firmwares before enabling by default
 - [ ] **Auto Fan Speed (opt-in, experimental)** — controller that selects fan speed (e.g., **P3/P4**) based on **ΔT** (discrete **1 °C** steps & hysteresis), active only in **HEAT/COOL**
 

--- a/custom_components/airzoneclouddaikin/__init__.py
+++ b/custom_components/airzoneclouddaikin/__init__.py
@@ -62,7 +62,15 @@ _DEFAULT_NOTIFY_STRINGS: dict[str, dict[str, str]] = {
 
 
 class AirzoneCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
-    """Typed coordinator that also carries the API handle."""
+    """Coordinator that aggregates installations and exposes device data.
+
+    ``data`` is a mapping of device IDs (Airzone or MAC) to device dicts as
+    returned by the API, refreshed on the coordinator interval. The coordinator
+    owns the ``AirzoneAPI`` instance used across platforms, triggers reauth if a
+    401 is encountered, and drives notification refresh scheduling. Per-entry
+    buckets under ``hass.data[DOMAIN][entry_id]`` hold auxiliary state such as
+    reauth flags and notification templates.
+    """
 
     api: AirzoneAPI
 

--- a/custom_components/airzoneclouddaikin/config_flow.py
+++ b/custom_components/airzoneclouddaikin/config_flow.py
@@ -101,18 +101,11 @@ class AirzoneConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         email = str(user_input.get(CONF_USERNAME, "")).strip()
         user_input[CONF_USERNAME] = email
+        password = str(user_input.get(CONF_PASSWORD, ""))
         # NOTE: We deliberately use the generic "invalid_auth" error here so that
         # empty credentials and bad credentials share the same translated message,
         # without introducing additional per-field error keys in translations.
-        if not email:
-            return self.async_show_form(
-                step_id="user",
-                data_schema=_user_schema(user_input),
-                errors={"base": "invalid_auth"},
-            )
-
-        password = str(user_input.get(CONF_PASSWORD, ""))
-        if not password:
+        if not email or not password:
             return self.async_show_form(
                 step_id="user",
                 data_schema=_user_schema(user_input),

--- a/custom_components/airzoneclouddaikin/helpers.py
+++ b/custom_components/airzoneclouddaikin/helpers.py
@@ -1,4 +1,20 @@
-"""Shared helpers for optimistic overlays and numeric clamps."""
+"""Helpers for optimistic overlays, numeric clamps, locks, and refreshes.
+
+Optimistic overlays: keep temporary values in
+``hass.data[DOMAIN][entry_id]["optimistic"]`` to bridge the gap between a user
+action and the next coordinator refresh. `optimistic_set` stores a value with
+an adaptive TTL derived from `_adaptive_ttl` (falls back to
+``OPTIMISTIC_TTL_SEC`` but stretches to ``scan_interval + 0.5`` when known).
+`optimistic_get` returns the overlay while it is still valid and cleans up
+expired entries; `optimistic_invalidate` removes overlays explicitly when the
+backend has caught up or a write failed. All helpers rely on `hass.loop.time()`
+for expiry and keep per-entry buckets keyed by config entry ID and device ID.
+
+Other utilities: `clamp_number` enforces ranges/steps on numeric inputs,
+`acquire_device_lock` returns per-device locks to serialize writes, and
+`schedule_post_write_refresh` coalesces delayed coordinator refreshes after a
+write to avoid redundant work.
+"""
 
 from __future__ import annotations
 

--- a/custom_components/airzoneclouddaikin/manifest.json
+++ b/custom_components/airzoneclouddaikin/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://github.com/eXPerience83/DKNCloud-HASS",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/eXPerience83/DKNCloud-HASS/issues",
-  "version": "0.4.1"
+  "version": "0.4.2"
 }

--- a/custom_components/airzoneclouddaikin/translations/de.json
+++ b/custom_components/airzoneclouddaikin/translations/de.json
@@ -1,0 +1,63 @@
+{
+  "title": "DKN Cloud for HASS",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Anmelden",
+        "description": "Geben Sie die E-Mail-Adresse und das Passwort Ihres Airzone-Cloud-Kontos ein.",
+        "data": {
+          "username": "E-Mail-Adresse",
+          "password": "Passwort",
+          "scan_interval": "Abfrageintervall (Sekunden)",
+          "expose_pii_identifiers": "PII-Kennungen anzeigen (erweitert)"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Erneut authentifizieren",
+        "description": "Ihr Token ist für {username} nicht mehr gültig. Geben Sie das Kontopasswort ein, um ein neues Token zu erstellen.",
+        "data": {
+          "password": "Passwort"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Ungültige E-Mail-Adresse oder ungültiges Passwort.",
+      "cannot_connect": "Verbindung zu Airzone Cloud nicht möglich.",
+      "timeout": "Die Anfrage hat das Zeitlimit überschritten. Bitte versuchen Sie es erneut.",
+      "unknown": "Unerwarteter Fehler. Weitere Details finden Sie in den Protokollen."
+    },
+    "abort": {
+      "reauth_successful": "Erneute Authentifizierung erfolgreich.",
+      "reauth_failed": "Erneute Authentifizierung fehlgeschlagen.",
+      "already_configured": "Dieses Konto ist bereits konfiguriert."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Optionen",
+        "description": "Der experimentelle HEAT_COOL-Modus ist optional, leitet Sollwerte über P7 und Lüftergeschwindigkeiten über P3 und gilt nur für Installationen, deren Geräte Kompatibilität melden.",
+        "data": {
+          "scan_interval": "Abfrageintervall (Sekunden)",
+          "expose_pii_identifiers": "PII-Kennungen anzeigen (erweitert)",
+          "enable_heat_cool_mode": "Experimentellen HEAT_COOL-Modus aktivieren (erfordert kompatible Installation; nutzt P7/P3-Routing)"
+        }
+      }
+    }
+  },
+  "exceptions": {
+    "wserver_not_connected": {
+      "message": "DKN-WServer nicht verbunden (422)"
+    }
+  },
+  "issues": {
+    "offline": {
+      "title": "DKN Cloud — {name} offline",
+      "description": "Verbindung um {ts_local} verloren. Letzter Kontakt: {last_iso} (vor etwa {mins} Min.)."
+    },
+    "online": {
+      "title": "DKN Cloud — {name} wieder online",
+      "description": "Verbindung um {ts_local} wiederhergestellt."
+    }
+  }
+}

--- a/custom_components/airzoneclouddaikin/translations/en.json
+++ b/custom_components/airzoneclouddaikin/translations/en.json
@@ -36,11 +36,11 @@
     "step": {
       "init": {
         "title": "Options",
-        "description": "Experimental HEAT_COOL mode is opt-in, routes setpoints via P7 and fan speeds via P3, and only takes effect for installations whose devices report compatibility.",
+        "description": "Experimental/beta HEAT_COOL mode is opt-in, routes setpoints via P7 and fan speeds via P3, and only takes effect for installations whose devices report compatibility.",
         "data": {
           "scan_interval": "Scan interval (seconds)",
           "expose_pii_identifiers": "Expose PII identifiers (advanced)",
-          "enable_heat_cool_mode": "Enable experimental HEAT_COOL mode (requires compatible installation; uses P7/P3 routing)"
+          "enable_heat_cool_mode": "Enable experimental/beta HEAT_COOL mode (requires compatible installation; uses P7/P3 routing)"
         }
       }
     }

--- a/custom_components/airzoneclouddaikin/translations/es.json
+++ b/custom_components/airzoneclouddaikin/translations/es.json
@@ -36,11 +36,11 @@
     "step": {
       "init": {
         "title": "Opciones",
-        "description": "El modo HEAT_COOL experimental es opt-in, usa P7 para la consigna y P3 para el ventilador, y solo tendrá efecto si alguna instalación informa que es compatible.",
+        "description": "El modo HEAT_COOL experimental/beta es opt-in, usa P7 para la consigna y P3 para el ventilador, y solo tendrá efecto si alguna instalación informa que es compatible.",
         "data": {
           "scan_interval": "Intervalo de sondeo (segundos)",
           "expose_pii_identifiers": "Exponer identificadores PII (avanzado)",
-          "enable_heat_cool_mode": "Activar modo HEAT_COOL experimental (requiere instalación compatible; usa ruteo P7/P3)"
+          "enable_heat_cool_mode": "Activar modo HEAT_COOL experimental/beta (requiere instalación compatible; usa ruteo P7/P3)"
         }
       }
     }

--- a/custom_components/airzoneclouddaikin/translations/fr.json
+++ b/custom_components/airzoneclouddaikin/translations/fr.json
@@ -1,0 +1,63 @@
+{
+  "title": "DKN Cloud for HASS",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connexion",
+        "description": "Saisissez l’adresse e-mail et le mot de passe de votre compte Airzone Cloud.",
+        "data": {
+          "username": "Email",
+          "password": "Mot de passe",
+          "scan_interval": "Intervalle d'interrogation (secondes)",
+          "expose_pii_identifiers": "Exposer les identifiants PII (avancé)"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Réauthentification",
+        "description": "Votre jeton n’est plus valide pour {username}. Entrez le mot de passe du compte pour générer un nouveau jeton.",
+        "data": {
+          "password": "Mot de passe"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Adresse e-mail ou mot de passe invalide.",
+      "cannot_connect": "Impossible de se connecter à Airzone Cloud.",
+      "timeout": "La requête a expiré. Veuillez réessayer.",
+      "unknown": "Erreur inattendue. Consultez les journaux pour plus de détails."
+    },
+    "abort": {
+      "reauth_successful": "Réauthentification réussie.",
+      "reauth_failed": "Échec de la réauthentification.",
+      "already_configured": "Ce compte est déjà configuré."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Options",
+        "description": "Le mode HEAT_COOL expérimental est optionnel, il envoie les consignes via P7 et les vitesses de ventilation via P3, et ne s’applique qu’aux installations dont les appareils déclarent être compatibles.",
+        "data": {
+          "scan_interval": "Intervalle d'interrogation (secondes)",
+          "expose_pii_identifiers": "Exposer les identifiants PII (avancé)",
+          "enable_heat_cool_mode": "Activer le mode HEAT_COOL expérimental (requiert une installation compatible ; utilise le routage P7/P3)"
+        }
+      }
+    }
+  },
+  "exceptions": {
+    "wserver_not_connected": {
+      "message": "Serveur DKN non connecté (422)"
+    }
+  },
+  "issues": {
+    "offline": {
+      "title": "DKN Cloud — {name} hors ligne",
+      "description": "Connexion perdue à {ts_local}. Dernier contact : {last_iso} (il y a environ {mins} min)."
+    },
+    "online": {
+      "title": "DKN Cloud — {name} de nouveau en ligne",
+      "description": "Connexion rétablie à {ts_local}."
+    }
+  }
+}

--- a/custom_components/airzoneclouddaikin/translations/it.json
+++ b/custom_components/airzoneclouddaikin/translations/it.json
@@ -1,0 +1,63 @@
+{
+  "title": "DKN Cloud for HASS",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Accesso",
+        "description": "Inserisci l'indirizzo email e la password del tuo account Airzone Cloud.",
+        "data": {
+          "username": "Email",
+          "password": "Password",
+          "scan_interval": "Intervallo di scansione (secondi)",
+          "expose_pii_identifiers": "Esporre identificatori PII (avanzato)"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Riautenticazione",
+        "description": "Il tuo token non è più valido per {username}. Inserisci la password dell'account per generare un nuovo token.",
+        "data": {
+          "password": "Password"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Email o password non validi.",
+      "cannot_connect": "Impossibile connettersi ad Airzone Cloud.",
+      "timeout": "La richiesta è scaduta. Riprova.",
+      "unknown": "Errore imprevisto. Controlla i registri per maggiori dettagli."
+    },
+    "abort": {
+      "reauth_successful": "Riautenticazione riuscita.",
+      "reauth_failed": "Riautenticazione non riuscita.",
+      "already_configured": "Questo account è già configurato."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opzioni",
+        "description": "La modalità sperimentale HEAT_COOL è facoltativa, instrada i setpoint tramite P7 e le velocità della ventola tramite P3 e si applica solo alle installazioni i cui dispositivi dichiarano compatibilità.",
+        "data": {
+          "scan_interval": "Intervallo di scansione (secondi)",
+          "expose_pii_identifiers": "Esporre identificatori PII (avanzato)",
+          "enable_heat_cool_mode": "Abilita modalità sperimentale HEAT_COOL (richiede installazione compatibile; utilizza instradamento P7/P3)"
+        }
+      }
+    }
+  },
+  "exceptions": {
+    "wserver_not_connected": {
+      "message": "Server DKN non connesso (422)"
+    }
+  },
+  "issues": {
+    "offline": {
+      "title": "DKN Cloud — {name} offline",
+      "description": "Connessione persa alle {ts_local}. Ultimo contatto: {last_iso} (circa {mins} min fa)."
+    },
+    "online": {
+      "title": "DKN Cloud — {name} di nuovo online",
+      "description": "Connessione ripristinata alle {ts_local}."
+    }
+  }
+}

--- a/custom_components/airzoneclouddaikin/translations/pt.json
+++ b/custom_components/airzoneclouddaikin/translations/pt.json
@@ -1,0 +1,63 @@
+{
+  "title": "DKN Cloud for HASS",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Iniciar sessão",
+        "description": "Introduza o email e a palavra-passe da sua conta Airzone Cloud.",
+        "data": {
+          "username": "Email",
+          "password": "Palavra-passe",
+          "scan_interval": "Intervalo de consulta (segundos)",
+          "expose_pii_identifiers": "Expor identificadores PII (avançado)"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Nova autenticação",
+        "description": "O seu token já não é válido para {username}. Introduza a palavra-passe da conta para gerar um novo token.",
+        "data": {
+          "password": "Palavra-passe"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Email ou palavra-passe inválidos.",
+      "cannot_connect": "Não é possível ligar ao Airzone Cloud.",
+      "timeout": "O pedido excedeu o tempo limite. Tente novamente.",
+      "unknown": "Erro inesperado. Verifique os registos para mais detalhes."
+    },
+    "abort": {
+      "reauth_successful": "Nova autenticação concluída.",
+      "reauth_failed": "A nova autenticação falhou.",
+      "already_configured": "Esta conta já está configurada."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opções",
+        "description": "O modo experimental HEAT_COOL é opcional, envia as definições através de P7 e as velocidades do ventilador via P3, e só se aplica a instalações cujos dispositivos indiquem compatibilidade.",
+        "data": {
+          "scan_interval": "Intervalo de consulta (segundos)",
+          "expose_pii_identifiers": "Expor identificadores PII (avançado)",
+          "enable_heat_cool_mode": "Ativar modo HEAT_COOL experimental (requer instalação compatível; utiliza encaminhamento P7/P3)"
+        }
+      }
+    }
+  },
+  "exceptions": {
+    "wserver_not_connected": {
+      "message": "Servidor DKN não ligado (422)"
+    }
+  },
+  "issues": {
+    "offline": {
+      "title": "DKN Cloud — {name} offline",
+      "description": "Ligação perdida às {ts_local}. Último contacto: {last_iso} (há cerca de {mins} min)."
+    },
+    "online": {
+      "title": "DKN Cloud — {name} de novo online",
+      "description": "Ligação restabelecida às {ts_local}."
+    }
+  }
+}

--- a/info.md
+++ b/info.md
@@ -121,7 +121,7 @@ heat_modes = {2,7,8}
 | 7  | heat-air         | **No**       | Unknown/tentative      | Unknown     | **Not exposed**; semantics unclear for our models. |
 | 8  | ventilate        | **Yes** (fallback) | **N/A**          | **P4**      | Use only if 3 unsupported and 8 supported (see below). |
 
-\* For `P2=4 (HEAT_COOL, heat-cold-auto)`, until broader validation: treat as **cold-type** for fan (**P3**) and setpoint (**P7**) by default. It remains **opt-in** and device-dependent.
+\* For `P2=4 (HEAT_COOL, heat-cold-auto)`, until broader validation: treat as **cold-type** for fan (**P3**) and setpoint (**P7**) by default. It remains an **opt-in experimental/beta** mode and is device-dependent.
   * Options flow toggle: “Enable experimental HEAT_COOL mode (requires compatible installation; routes setpoint via P7 and fan via P3)”. The checkbox is always available so users can opt in ahead of time, but the integration ignores the flag unless at least one device advertises `modes[3] == "1"`.
 
 **Ventilate selection policy (P2=3 vs P2=8)**

--- a/tests/test_airzone_api.py
+++ b/tests/test_airzone_api.py
@@ -1,0 +1,175 @@
+"""HTTP client retry behavior tests without Home Assistant dependencies."""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("aiohttp")
+
+from aiohttp import ClientResponseError, ClientSession
+from aiohttp.client_reqrep import RequestInfo
+from multidict import CIMultiDict
+from yarl import URL
+
+ha_module = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
+exceptions_module = types.ModuleType("homeassistant.exceptions")
+
+
+class HomeAssistantError(Exception):
+    """Minimal Home Assistant error placeholder."""
+
+
+exceptions_module.HomeAssistantError = HomeAssistantError
+ha_module.exceptions = exceptions_module
+sys.modules.setdefault("homeassistant.exceptions", exceptions_module)
+
+from custom_components.airzoneclouddaikin.airzone_api import AirzoneAPI  # noqa: E402
+
+
+def _client_response_error(
+    status: int, headers: dict[str, str] | None = None
+) -> ClientResponseError:
+    """Create a ClientResponseError with minimal request context."""
+
+    request_info = RequestInfo(
+        URL("https://example.com"),
+        "GET",
+        CIMultiDict(),
+        URL("https://example.com"),
+    )
+    return ClientResponseError(
+        request_info,
+        history=(),
+        status=status,
+        message="",
+        headers=headers,
+    )
+
+
+def _make_api(
+    monkeypatch: pytest.MonkeyPatch, responses: list[object]
+) -> tuple[AirzoneAPI, list[float]]:
+    """Create an API with deterministic time and response sequencing."""
+
+    api = AirzoneAPI(username="user@example.com", session=AsyncMock(spec=ClientSession))
+    sleeps: list[float] = []
+    clock = {"now": 0.0}
+
+    monkeypatch.setattr(api, "_now", lambda: clock["now"])
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+        clock["now"] += seconds
+
+    monkeypatch.setattr(api, "_sleep", fake_sleep)
+    monkeypatch.setattr(api, "_request", AsyncMock(side_effect=responses))
+    return api, sleeps
+
+
+@pytest.mark.asyncio
+async def test_login_success_sets_token_and_preserves_password() -> None:
+    api = AirzoneAPI(
+        username="user@example.com",
+        password="secret",
+        session=AsyncMock(spec=ClientSession),
+    )
+    with patch.object(
+        api,
+        "_request",
+        AsyncMock(return_value={"user": {"authentication_token": "tok"}}),
+    ):
+        assert await api.login() is True
+
+    assert api.token == "tok"
+    assert api.password == "secret"
+
+
+@pytest.mark.asyncio
+async def test_login_handles_unauthorized() -> None:
+    api = AirzoneAPI(
+        username="user@example.com",
+        password="secret",
+        session=AsyncMock(spec=ClientSession),
+    )
+    with patch.object(
+        api,
+        "_request",
+        AsyncMock(side_effect=_client_response_error(status=401)),
+    ):
+        assert await api.login() is False
+
+    assert api.token is None
+
+
+@pytest.mark.asyncio
+async def test_authed_request_retries_429_with_retry_after(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "custom_components.airzoneclouddaikin.airzone_api.random.uniform",
+        lambda *_: 0.0,
+    )
+    retry_error = _client_response_error(status=429, headers={"Retry-After": "2"})
+    api, sleeps = _make_api(monkeypatch, [retry_error, {"ok": True}])
+
+    result = await api._authed_request_with_retries("GET", "/foo")
+
+    assert result == {"ok": True}
+    assert sleeps == [2.0]
+    assert api._cooldown_until == pytest.approx(2.0)
+
+
+@pytest.mark.asyncio
+async def test_authed_request_5xx_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "custom_components.airzoneclouddaikin.airzone_api.random.uniform",
+        lambda *_: 0.0,
+    )
+    errors = [_client_response_error(status=500) for _ in range(4)]
+    api, sleeps = _make_api(monkeypatch, errors)
+
+    with pytest.raises(ClientResponseError):
+        await api._authed_request_with_retries("GET", "/bar")
+
+    assert sleeps == pytest.approx([0.6, 1.2, 2.4])
+    assert api._cooldown_until == 0.0
+
+
+@pytest.mark.asyncio
+async def test_timeout_retries_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "custom_components.airzoneclouddaikin.airzone_api.random.uniform",
+        lambda *_: 0.0,
+    )
+    api, sleeps = _make_api(monkeypatch, [TimeoutError(), {"ok": True}])
+
+    result = await api._authed_request_with_retries("GET", "/baz")
+
+    assert result == {"ok": True}
+    assert sleeps == pytest.approx([0.4])
+
+
+@pytest.mark.asyncio
+async def test_error_logs_do_not_leak_password(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    api = AirzoneAPI(
+        username="user@example.com",
+        password="topsecret",
+        session=AsyncMock(spec=ClientSession),
+    )
+    with patch.object(
+        api,
+        "_request",
+        AsyncMock(side_effect=_client_response_error(status=503)),
+    ):
+        caplog.set_level("DEBUG")
+        with pytest.raises(ClientResponseError):
+            await api._authed_request_with_retries("GET", "/api/secure?pw=topsecret")
+
+    assert "topsecret" not in caplog.text
+    assert "user@example.com" not in caplog.text

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,467 @@
+"""Config and options flow tests using lightweight Home Assistant stubs."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+class FlowResultType:
+    """Minimal FlowResultType replacement used by the stubs."""
+
+    FORM = "form"
+    CREATE_ENTRY = "create_entry"
+    ABORT = "abort"
+
+
+class AbortFlow(Exception):
+    """Raised when a duplicate unique ID is configured."""
+
+
+class ConfigEntry:
+    """Simple ConfigEntry stand-in for tests."""
+
+    _id = 0
+
+    def __init__(
+        self,
+        *,
+        domain: str,
+        data: dict[str, Any] | None = None,
+        options: dict[str, Any] | None = None,
+        unique_id: str | None = None,
+    ) -> None:
+        ConfigEntry._id += 1
+        self.entry_id = f"entry_{ConfigEntry._id}"
+        self.domain = domain
+        self.data = data or {}
+        self.options = options or {}
+        self.unique_id = unique_id
+
+    def add_to_hass(self, hass: HassStub) -> None:
+        hass.config_entries._entries.append(self)
+
+
+class ConfigEntries:
+    """Collection helper for ConfigEntry stubs."""
+
+    def __init__(self) -> None:
+        self._entries: list[ConfigEntry] = []
+
+    def async_get_entry(self, entry_id: str) -> ConfigEntry | None:
+        for entry in self._entries:
+            if entry.entry_id == entry_id:
+                return entry
+        return None
+
+    def async_entries(self, domain: str | None = None) -> list[ConfigEntry]:
+        if domain is None:
+            return list(self._entries)
+        return [entry for entry in self._entries if entry.domain == domain]
+
+    def async_update_entry(
+        self, entry: ConfigEntry, *, options: dict[str, Any]
+    ) -> None:
+        entry.options = options
+
+    def _unique_id_exists(self, unique_id: str | None) -> bool:
+        if unique_id is None:
+            return False
+        return any(entry.unique_id == unique_id for entry in self._entries)
+
+
+class ConfigFlow:
+    """Minimal ConfigFlow base to satisfy the integration flow."""
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        """Allow Home Assistant-style subclass kwargs like domain."""
+        super().__init_subclass__()
+
+    def __init__(self) -> None:
+        self.hass: HassStub | None = None
+        self.context: dict[str, Any] = {}
+        self._unique_id: str | None = None
+
+    async def async_set_unique_id(self, unique_id: str) -> None:
+        self._unique_id = unique_id
+
+    def _abort_if_unique_id_configured(self) -> None:
+        if self.hass and self.hass.config_entries._unique_id_exists(self._unique_id):
+            raise AbortFlow()
+
+    def async_show_form(
+        self, *, step_id: str, data_schema: Any, errors: dict[str, str] | None = None
+    ) -> dict[str, Any]:
+        return {
+            "type": FlowResultType.FORM,
+            "step_id": step_id,
+            "data_schema": data_schema,
+            "errors": errors or {},
+        }
+
+    def async_abort(self, *, reason: str) -> dict[str, Any]:
+        return {"type": FlowResultType.ABORT, "reason": reason}
+
+    def async_create_entry(
+        self, *, title: str, data: dict[str, Any], options: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        return {
+            "type": FlowResultType.CREATE_ENTRY,
+            "title": title,
+            "data": data,
+            "options": options or {},
+        }
+
+
+class OptionsFlow:
+    """Minimal OptionsFlow base."""
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        self.config_entry = config_entry
+        self.hass: HassStub | None = None
+
+    def async_show_form(
+        self, *, step_id: str, data_schema: Any, errors: dict[str, str] | None = None
+    ) -> dict[str, Any]:
+        return {
+            "type": FlowResultType.FORM,
+            "step_id": step_id,
+            "data_schema": data_schema,
+            "errors": errors or {},
+        }
+
+    def async_create_entry(
+        self, *, title: str = "", data: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        return {"type": FlowResultType.CREATE_ENTRY, "title": title, "data": data or {}}
+
+
+class HassStub:
+    """Lightweight Home Assistant stub with config entry tracking."""
+
+    def __init__(self) -> None:
+        self.config_entries = ConfigEntries()
+        self.data: dict[str, Any] = {}
+
+
+def _install_voluptuous_stub() -> None:
+    """Provide a tiny voluptuous stub to avoid external dependency."""
+
+    vol_module = types.ModuleType("voluptuous")
+
+    class Schema:  # pragma: no cover - structure only
+        def __init__(self, data: Any) -> None:
+            self.data = data
+
+    class Marker:  # pragma: no cover - structure only
+        def __init__(self, key: Any, default: Any | None = None) -> None:
+            self.key = key
+            self.default = default
+
+    class Required(Marker):
+        pass
+
+    class Optional(Marker):
+        pass
+
+    class Range:  # pragma: no cover - structure only
+        def __init__(self, min: int | None = None, max: int | None = None) -> None:
+            self.min = min
+            self.max = max
+
+    def All(*validators: Any) -> tuple[Any, ...]:  # noqa: N802 - match voluptuous API
+        return validators
+
+    def Coerce(target_type: type) -> Any:  # noqa: N802 - match voluptuous API
+        return target_type
+
+    vol_module.Schema = Schema
+    vol_module.Required = Required
+    vol_module.Optional = Optional
+    vol_module.Range = Range
+    vol_module.All = All
+    vol_module.Coerce = Coerce
+
+    sys.modules["voluptuous"] = vol_module
+
+
+def _install_homeassistant_stubs() -> None:
+    """Install minimal Home Assistant modules for importing config_flow."""
+
+    ha_module = sys.modules.setdefault(
+        "homeassistant", types.ModuleType("homeassistant")
+    )
+
+    config_entries_module = types.ModuleType("homeassistant.config_entries")
+    config_entries_module.ConfigFlow = ConfigFlow
+    config_entries_module.OptionsFlow = OptionsFlow
+    config_entries_module.ConfigEntry = ConfigEntry
+    config_entries_module.SOURCE_USER = "user"
+    config_entries_module.SOURCE_REAUTH = "reauth"
+    sys.modules["homeassistant.config_entries"] = config_entries_module
+
+    const_module = types.ModuleType("homeassistant.const")
+    const_module.CONF_USERNAME = "username"
+    const_module.CONF_PASSWORD = "password"
+    sys.modules["homeassistant.const"] = const_module
+
+    core_module = types.ModuleType("homeassistant.core")
+    sys.modules["homeassistant.core"] = core_module
+
+    data_entry_flow_module = types.ModuleType("homeassistant.data_entry_flow")
+    data_entry_flow_module.FlowResultType = FlowResultType
+    data_entry_flow_module.FlowResult = dict
+    sys.modules["homeassistant.data_entry_flow"] = data_entry_flow_module
+
+    helpers_module = sys.modules.setdefault(
+        "homeassistant.helpers", types.ModuleType("homeassistant.helpers")
+    )
+
+    aiohttp_client_module = types.ModuleType("homeassistant.helpers.aiohttp_client")
+
+    def async_get_clientsession(_hass: HassStub) -> object:
+        return object()
+
+    aiohttp_client_module.async_get_clientsession = async_get_clientsession
+    sys.modules["homeassistant.helpers.aiohttp_client"] = aiohttp_client_module
+
+    cv_module = types.ModuleType("homeassistant.helpers.config_validation")
+
+    def boolean(value: Any) -> bool:
+        return bool(value)
+
+    def string(value: Any) -> str:
+        return str(value)
+
+    cv_module.boolean = boolean
+    cv_module.string = string
+    helpers_module.config_validation = cv_module
+    sys.modules["homeassistant.helpers.config_validation"] = cv_module
+
+    ha_module.config_entries = config_entries_module
+    ha_module.const = const_module
+    ha_module.core = core_module
+    ha_module.data_entry_flow = data_entry_flow_module
+    ha_module.helpers = helpers_module
+
+
+_install_voluptuous_stub()
+_install_homeassistant_stubs()
+
+from homeassistant.config_entries import SOURCE_REAUTH  # type: ignore  # noqa: E402
+from homeassistant.const import (  # type: ignore  # noqa: E402
+    CONF_PASSWORD,
+    CONF_USERNAME,
+)
+from homeassistant.data_entry_flow import (  # type: ignore  # noqa: E402
+    FlowResultType as HAFlowResultType,
+)
+
+from custom_components.airzoneclouddaikin.config_flow import (  # noqa: E402
+    CONF_EXPOSE_PII,
+    CONF_SCAN_INTERVAL,
+    AirzoneConfigFlow,
+    AirzoneOptionsFlow,
+)
+from custom_components.airzoneclouddaikin.const import (  # noqa: E402
+    CONF_ENABLE_HEAT_COOL,
+    DOMAIN,
+)
+
+
+def _run(coro: Any) -> Any:
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+@pytest.fixture
+def hass() -> HassStub:
+    """Provide a fresh Hass stub for each test."""
+
+    return HassStub()
+
+
+@pytest.fixture
+def api_mock() -> AsyncMock:
+    """Fixture that installs a stub AirzoneAPI returning a shared mock."""
+
+    api_mock = AsyncMock()
+    api_mock.login = AsyncMock(return_value="login-token")
+    api_mock.token = "login-token"
+    api_mock.clear_password = lambda: None
+
+    module_path = "custom_components.airzoneclouddaikin.airzone_api"
+    api_module = types.ModuleType(module_path)
+    api_module.AirzoneAPI = lambda *args, **kwargs: api_mock
+    sys.modules[module_path] = api_module
+
+    parent = sys.modules.get("custom_components.airzoneclouddaikin")
+    if parent is not None:
+        parent.airzone_api = api_module
+
+    return api_mock
+
+
+def test_user_step_shows_initial_form(hass: HassStub) -> None:
+    flow = AirzoneConfigFlow()
+    flow.hass = hass
+
+    result = _run(flow.async_step_user(user_input=None))
+
+    assert result["type"] is HAFlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert "data_schema" in result
+
+
+def test_user_step_success_creates_entry(hass: HassStub, api_mock: AsyncMock) -> None:
+    flow = AirzoneConfigFlow()
+    flow.hass = hass
+
+    user_input = {
+        CONF_USERNAME: "User@Example.Com ",
+        CONF_PASSWORD: "secret",
+        CONF_SCAN_INTERVAL: 15,
+        CONF_EXPOSE_PII: True,
+    }
+
+    result = _run(flow.async_step_user(user_input=user_input))
+
+    assert result["type"] is HAFlowResultType.CREATE_ENTRY
+    normalized_email = user_input[CONF_USERNAME].strip()
+    assert result["title"] == normalized_email
+    assert result["data"] == {CONF_USERNAME: normalized_email}
+
+    options = result["options"]
+    assert options["user_token"] == "login-token"
+    assert options[CONF_SCAN_INTERVAL] == 15
+    assert options[CONF_EXPOSE_PII] is True
+    assert CONF_ENABLE_HEAT_COOL not in options
+
+
+def test_user_step_invalid_auth_from_api(hass: HassStub, api_mock: AsyncMock) -> None:
+    flow = AirzoneConfigFlow()
+    flow.hass = hass
+
+    api_mock.login = AsyncMock(return_value="")
+    api_mock.token = ""
+
+    result = _run(
+        flow.async_step_user(
+            user_input={
+                CONF_USERNAME: "user@example.com",
+                CONF_PASSWORD: "secret",
+                CONF_SCAN_INTERVAL: 15,
+                CONF_EXPOSE_PII: False,
+            }
+        )
+    )
+
+    assert result["type"] is HAFlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+def test_user_step_cannot_connect(hass: HassStub, api_mock: AsyncMock) -> None:
+    flow = AirzoneConfigFlow()
+    flow.hass = hass
+
+    api_mock.login = AsyncMock(side_effect=RuntimeError("boom"))
+
+    result = _run(
+        flow.async_step_user(
+            user_input={
+                CONF_USERNAME: "user@example.com",
+                CONF_PASSWORD: "secret",
+                CONF_SCAN_INTERVAL: 15,
+                CONF_EXPOSE_PII: False,
+            }
+        )
+    )
+
+    assert result["type"] is HAFlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+def test_reauth_flow_success_updates_token(hass: HassStub, api_mock: AsyncMock) -> None:
+    entry = ConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "user@example.com"},
+        options={
+            "user_token": "old-token",
+            CONF_SCAN_INTERVAL: 10,
+            CONF_EXPOSE_PII: False,
+        },
+        unique_id="user@example.com",
+    )
+    entry.add_to_hass(hass)
+
+    flow = AirzoneConfigFlow()
+    flow.hass = hass
+    flow.context = {"source": SOURCE_REAUTH, "entry_id": entry.entry_id}
+
+    result = _run(flow.async_step_reauth(entry.data))
+
+    assert result["type"] is HAFlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result2 = _run(
+        flow.async_step_reauth_confirm(user_input={CONF_PASSWORD: "new-secret"})
+    )
+
+    assert result2["type"] is HAFlowResultType.ABORT
+    assert result2["reason"] == "reauth_successful"
+    assert entry.options["user_token"] == "login-token"
+    assert entry.options[CONF_SCAN_INTERVAL] == 10
+    assert entry.options[CONF_EXPOSE_PII] is False
+
+
+def test_options_flow_updates_options_and_preserves_hidden_keys(hass: HassStub) -> None:
+    entry = ConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "user@example.com"},
+        options={
+            "user_token": "tok-123",
+            "hidden_key": "keep-me",
+            CONF_SCAN_INTERVAL: 10,
+            CONF_EXPOSE_PII: False,
+            CONF_ENABLE_HEAT_COOL: False,
+        },
+        unique_id="user@example.com",
+    )
+    entry.add_to_hass(hass)
+
+    flow = AirzoneOptionsFlow(entry)
+    flow.hass = hass
+
+    result = _run(flow.async_step_init(user_input=None))
+
+    assert result["type"] is HAFlowResultType.FORM
+    assert result["step_id"] == "init"
+    assert "data_schema" in result
+
+    result2 = _run(
+        flow.async_step_init(
+            user_input={
+                CONF_SCAN_INTERVAL: 20,
+                CONF_EXPOSE_PII: True,
+                CONF_ENABLE_HEAT_COOL: True,
+            }
+        )
+    )
+
+    assert result2["type"] is HAFlowResultType.CREATE_ENTRY
+    new_options: dict[str, Any] = result2["data"]
+    assert new_options[CONF_SCAN_INTERVAL] == 20
+    assert new_options[CONF_EXPOSE_PII] is True
+    assert new_options[CONF_ENABLE_HEAT_COOL] is True
+    assert new_options["user_token"] == "tok-123"
+    assert new_options["hidden_key"] == "keep-me"

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -164,3 +164,54 @@ def test_diagnostics_redacts_sensitive_fields() -> None:
     assert "-3.7038" not in flattened
     assert '"mac"' not in flattened
     assert '"latitude"' not in flattened
+
+
+def test_diagnostics_redacts_extended_pii_fields() -> None:
+    """Redaction should cover additional sensitive fields in entries and devices."""
+
+    hass = DummyHass()
+    entry = DummyConfigEntry()
+    entry.data.update(
+        {
+            "installation_id": "install-123",
+            "spot_name": "My Home",
+            "complete_name": "John Doe",
+            "time_zone": "Europe/Madrid",
+        }
+    )
+    entry.options.update(
+        {
+            "installation_id": "install-123",
+            "time_zone": "Europe/Madrid",
+            "spot_name": "My Home",
+            "complete_name": "John Doe",
+        }
+    )
+
+    coordinator = DummyCoordinator()
+    coordinator.data["device-1"].update(
+        {
+            "installation_id": "install-123",
+            "spot_name": "My Home",
+            "complete_name": "John Doe",
+            "time_zone": "Europe/Madrid",
+            "device_ids": ["dev-1", "dev-2"],
+            "metadata": {"owner_id": "owner-123"},
+        }
+    )
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {"coordinator": coordinator}
+
+    result = asyncio.run(async_get_config_entry_diagnostics(hass, entry))
+
+    options = result["entry"]["options"]
+    assert options["installation_id"] == "***"
+    assert options["time_zone"] == "***"
+    assert options["spot_name"] == "***"
+    assert options["complete_name"] == "***"
+
+    flattened = str(result)
+    assert "install-123" not in flattened
+    assert "Europe/Madrid" not in flattened
+    assert "My Home" not in flattened
+    assert "owner-123" not in flattened

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,0 +1,331 @@
+"""Translation coverage tests for a Home Assistant integration.
+
+This test suite assumes the standard structure:
+    custom_components/<INTEGRATION_DOMAIN>/
+        ├── translations/en.json
+        ├── config_flow.py
+        └── const.py  (optional but recommended)
+
+To reuse it in another integration, change INTEGRATION_DOMAIN below.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from typing import Any
+
+# 🔧 Adjust this per repository
+INTEGRATION_DOMAIN = "airzoneclouddaikin"
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+COMPONENT_DIR = PROJECT_ROOT / "custom_components" / INTEGRATION_DOMAIN
+TRANSLATIONS_DIR = COMPONENT_DIR / "translations"
+CONFIG_FLOW_PATH = COMPONENT_DIR / "config_flow.py"
+CONST_PATH = COMPONENT_DIR / "const.py"
+
+
+def _flatten_keys(data: dict[str, Any], prefix: str = "") -> set[str]:
+    """Flatten nested dict keys into dotted paths."""
+
+    keys: set[str] = set()
+    for key, value in data.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            keys.update(_flatten_keys(value, path))
+        else:
+            keys.add(path)
+    return keys
+
+
+def _load_translation(path: Path) -> dict[str, Any]:
+    """Load a translation JSON file."""
+
+    if not path.is_file():
+        raise AssertionError(f"Missing translation file: {path}")
+
+    with path.open("r", encoding="utf-8") as file:
+        return json.load(file)
+
+
+def test_translations_match_english_keyset() -> None:
+    """Verify all locale files mirror the English translation keyset."""
+
+    en_path = TRANSLATIONS_DIR / "en.json"
+    english_keys = _flatten_keys(_load_translation(en_path))
+
+    problems: list[str] = []
+
+    for translation_path in TRANSLATIONS_DIR.glob("*.json"):
+        if translation_path.name == "en.json":
+            continue
+
+        locale_keys = _flatten_keys(_load_translation(translation_path))
+
+        missing = english_keys - locale_keys
+        extra = locale_keys - english_keys
+
+        if missing or extra:
+            problems.append(
+                f"{translation_path.name}: missing {sorted(missing)} extra {sorted(extra)}"
+            )
+
+    assert not problems, "Translation keys mismatch: " + "; ".join(problems)
+
+
+def test_config_flow_translation_keys_present() -> None:
+    """Ensure config/options flow keys referenced in code exist in English JSON."""
+
+    english = _flatten_keys(_load_translation(TRANSLATIONS_DIR / "en.json"))
+
+    flow_keys = _extract_config_flow_keys()
+
+    missing = flow_keys - english
+
+    assert not missing, f"Missing config_flow translation keys: {sorted(missing)}"
+
+
+def _extract_constant_assignments(tree: ast.AST) -> dict[str, str]:
+    """Collect string literal assignments from an AST."""
+
+    constants: dict[str, str] = {}
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            target_name: str | None = None
+
+            if isinstance(node, ast.Assign):
+                if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+                    continue
+                target_name = node.targets[0].id
+                value = node.value
+            else:
+                if not isinstance(node.target, ast.Name):
+                    continue
+                target_name = node.target.id
+                value = node.value
+
+            if (
+                target_name
+                and isinstance(value, ast.Constant)
+                and isinstance(value.value, str)
+            ):
+                constants[target_name] = value.value
+
+    return constants
+
+
+def _resolve_name(name: str, mapping: dict[str, str]) -> str | None:
+    """Resolve a variable name to its string value if known."""
+
+    return mapping.get(name)
+
+
+def _fields_from_schema_call(call: ast.Call, mapping: dict[str, str]) -> set[str]:
+    """Extract field keys from a vol.Schema(...) call."""
+
+    if not call.args:
+        return set()
+
+    arg = call.args[0]
+    if not isinstance(arg, ast.Dict):
+        return set()
+
+    fields: set[str] = set()
+
+    for key in arg.keys:
+        if not isinstance(key, ast.Call):
+            continue
+
+        if not isinstance(key.func, ast.Attribute):
+            continue
+
+        if key.func.attr not in {"Required", "Optional"}:
+            continue
+
+        if not key.args:
+            continue
+
+        selector = key.args[0]
+
+        if isinstance(selector, ast.Constant) and isinstance(selector.value, str):
+            fields.add(selector.value)
+        elif isinstance(selector, ast.Name):
+            resolved = _resolve_name(selector.id, mapping)
+            if resolved:
+                fields.add(resolved)
+
+    return fields
+
+
+def _extract_schema_fields(
+    tree: ast.AST, mapping: dict[str, str]
+) -> dict[str, set[str]]:
+    """Map schema helper names to their field keys."""
+
+    fields: dict[str, set[str]] = {}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name in {
+            "_user_schema",
+            "_options_schema",
+        }:
+            returns = [
+                child for child in ast.walk(node) if isinstance(child, ast.Return)
+            ]
+            for ret in returns:
+                if isinstance(ret.value, ast.Call):
+                    fields.setdefault(node.name, set()).update(
+                        _fields_from_schema_call(ret.value, mapping)
+                    )
+
+        if isinstance(node, ast.Assign):
+            if (
+                isinstance(node.targets[0], ast.Name)
+                and isinstance(node.value, ast.Call)
+                and isinstance(node.value.func, ast.Attribute)
+                and node.value.func.attr == "Schema"
+            ):
+                name = node.targets[0].id
+                fields.setdefault(name, set()).update(
+                    _fields_from_schema_call(node.value, mapping)
+                )
+
+    return fields
+
+
+def _is_options_flow_class(node: ast.ClassDef) -> bool:
+    """Heuristic to decide if a class represents an options flow."""
+
+    for base in node.bases:
+        if isinstance(base, ast.Name) and "OptionsFlow" in base.id:
+            return True
+        if isinstance(base, ast.Attribute) and base.attr == "OptionsFlow":
+            return True
+    return False
+
+
+def _extract_config_flow_keys() -> set[str]:
+    """Parse config_flow.py to derive translation keys used in flows."""
+
+    if not CONFIG_FLOW_PATH.is_file():
+        raise AssertionError(f"Missing config_flow.py at {CONFIG_FLOW_PATH}")
+
+    config_tree = ast.parse(CONFIG_FLOW_PATH.read_text(encoding="utf-8"))
+    const_tree: ast.AST | None = None
+
+    if CONST_PATH.is_file():
+        const_tree = ast.parse(CONST_PATH.read_text(encoding="utf-8"))
+
+    manual_mapping = {
+        "CONF_USERNAME": "username",
+        "CONF_PASSWORD": "password",
+        "CONF_API_KEY": "api_key",
+        "CONF_LATITUDE": "latitude",
+        "CONF_LONGITUDE": "longitude",
+        "CONF_LANGUAGE": "language",
+        "CONF_SCAN_INTERVAL": "scan_interval",
+    }
+
+    mapping: dict[str, str] = {**manual_mapping}
+
+    if const_tree is not None:
+        mapping.update(_extract_constant_assignments(const_tree))
+
+    mapping.update(_extract_constant_assignments(config_tree))
+
+    schema_fields = _extract_schema_fields(config_tree, mapping)
+
+    keys: set[str] = set()
+
+    class FlowVisitor(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.class_stack: list[ast.ClassDef] = []
+            self.local_schema_vars: dict[str, set[str]] = dict(schema_fields)
+
+        def visit_ClassDef(self, node: ast.ClassDef) -> None:  # noqa: N802
+            self.class_stack.append(node)
+            self.generic_visit(node)
+            self.class_stack.pop()
+
+        def visit_Assign(self, node: ast.Assign) -> None:  # noqa: N802
+            if (
+                isinstance(node.targets[0], ast.Name)
+                and isinstance(node.value, ast.Call)
+                and isinstance(node.value.func, ast.Attribute)
+                and node.value.func.attr == "Schema"
+            ):
+                name = node.targets[0].id
+                self.local_schema_vars.setdefault(name, set()).update(
+                    _fields_from_schema_call(node.value, mapping)
+                )
+            self.generic_visit(node)
+
+        def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+            prefix = "config"
+            if self.class_stack and _is_options_flow_class(self.class_stack[-1]):
+                prefix = "options"
+
+            func_attr: str | None = None
+            if isinstance(node.func, ast.Attribute):
+                func_attr = node.func.attr
+
+            if func_attr == "async_show_form":
+                self._handle_show_form(node, prefix)
+
+            if func_attr == "async_abort":
+                self._handle_abort(node, prefix)
+
+            self.generic_visit(node)
+
+        def _handle_show_form(self, node: ast.Call, prefix: str) -> None:
+            step_id: str | None = None
+            schema_name: str | None = None
+            inline_schema_fields: set[str] = set()
+
+            for kw in node.keywords:
+                if kw.arg == "step_id" and isinstance(kw.value, ast.Constant):
+                    step_id = str(kw.value.value)
+                if kw.arg == "data_schema":
+                    if isinstance(kw.value, ast.Name):
+                        schema_name = kw.value.id
+                    elif isinstance(kw.value, ast.Call):
+                        if (
+                            isinstance(kw.value.func, ast.Attribute)
+                            and kw.value.func.attr == "Schema"
+                        ):
+                            inline_schema_fields.update(
+                                _fields_from_schema_call(kw.value, mapping)
+                            )
+                if kw.arg == "errors" and isinstance(kw.value, ast.Dict):
+                    for err_value in kw.value.values:
+                        if isinstance(err_value, ast.Constant) and isinstance(
+                            err_value.value, str
+                        ):
+                            keys.add(f"{prefix}.error.{err_value.value}")
+
+            if not step_id:
+                return
+
+            keys.add(f"{prefix}.step.{step_id}.title")
+            keys.add(f"{prefix}.step.{step_id}.description")
+
+            if schema_name and schema_name in self.local_schema_vars:
+                for field in self.local_schema_vars[schema_name]:
+                    keys.add(f"{prefix}.step.{step_id}.data.{field}")
+
+            for field in inline_schema_fields:
+                keys.add(f"{prefix}.step.{step_id}.data.{field}")
+
+        def _handle_abort(self, node: ast.Call, prefix: str) -> None:
+            for kw in node.keywords:
+                if (
+                    kw.arg == "reason"
+                    and isinstance(kw.value, ast.Constant)
+                    and isinstance(kw.value.value, str)
+                ):
+                    keys.add(f"{prefix}.abort.{kw.value.value}")
+
+    FlowVisitor().visit(config_tree)
+
+    return keys


### PR DESCRIPTION
### **User description**
## Summary
- streamline the user-step credential validation to handle missing email or password together while keeping existing error handling

## Testing
- pytest -q
- ruff check .


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692494bb98888324bc4524d222e84c14)


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Add French, Portuguese, Italian, German translations for config/options flows and notifications

- Consolidate empty credential validation to check email and password together

- Introduce comprehensive test suites for API retry behavior, config flow, and translation coverage

- Enhance documentation with localization details and update version to 0.4.2


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Translation Files<br/>FR, PT, IT, DE"] --> B["Config/Options Flows<br/>Localized UI"]
  C["Credential Validation<br/>Consolidation"] --> D["Config Flow<br/>Unified Error Handling"]
  E["Test Suites<br/>API, Config, Translations"] --> F["Quality Assurance<br/>Coverage & Regression"]
  G["Documentation Updates<br/>Version 0.4.2"] --> H["README & Changelog<br/>Localization Info"]
  B --> I["Enhanced UX<br/>Multi-language Support"]
  D --> I
  F --> I
  H --> I
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>de.json</strong><dd><code>Add German translation for config and options flows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/33/files#diff-05f1d17c34113eae229ebea0f8387b02f7b67b7f7ed135d59caaba7684b833dd">+63/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fr.json</strong><dd><code>Add French translation for config and options flows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/33/files#diff-8ae70cefb9bffc6a3c26a890e7f2419b5c8cef19a739681f4920319ec7d9458a">+63/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>it.json</strong><dd><code>Add Italian translation for config and options flows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/33/files#diff-b2cf29478cc84ecd27726f81ee7c3483d1cc03692242be4a6a26aad7cb0a9dae">+63/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pt.json</strong><dd><code>Add Portuguese translation for config and options flows</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/33/files#diff-9559ac48ebec6b07357dee8f4dbae28384eed51a86bb30dce4051092aa5add9f">+63/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>en.json</strong><dd><code>Update English translations to mark HEAT_COOL as experimental/beta</code></dd></td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/33/files#diff-6a19cda0da178a826b4067b71c15001a63be6a25416e0ee6019355d697251f3b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>es.json</strong><dd><code>Update Spanish translations to mark HEAT_COOL as experimental/beta</code></dd></td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/33/files#diff-fc625454e4313525895345c220ae63ef26f3038f33d39256f1567660600707e8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong><dd><code>Enhance AirzoneCoordinator docstring with detailed responsibilities</code></dd></td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/33/files#diff-0a2b04957b431594d35fbd3d53311cac51b252756aa7ecc03da2d3954c05aa56">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>helpers.py</strong><dd><code>Expand helpers module docstring with comprehensive feature </code><br><code>descriptions</code></dd></td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/33/files#diff-08dedc077188d2ed23f51fd505d640e01fc10c831197de7f8d56f9bf65e17e7a">+17/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Add version 0.4.2 entry and refine historical terminology</code></dd></td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/33/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+35/-20</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Add localization section and update HEAT_COOL mode description</code></dd></td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/33/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>info.md</strong><dd><code>Update HEAT_COOL mode documentation to reflect experimental/beta </code><br><code>status</code></dd></td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/33/files#diff-e61886ecb4349d231b56f665c58dde8f4837ea94a9b2cb2cb7dcc259718123f2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>config_flow.py</strong><dd><code>Consolidate empty email and password validation into single check</code></dd></td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/33/files#diff-70f229c9e2bc68445d071d80f4be1733b1d2b6d833c5c1c79e0fba3cedf86f9f">+2/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>test_airzone_api.py</strong><dd><code>Add HTTP client retry behavior tests without Home Assistant </code><br><code>dependencies</code></dd></td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/33/files#diff-44e4538dfc94f13a0769559d5c5ebc7cf54e7b59cc02ff3a364a3a2d2699af7b">+175/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_config_flow.py</strong><dd><code>Add comprehensive config and options flow tests with lightweight stubs</code></dd></td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/33/files#diff-3e0062aab0171da6d72888d9668e1fa5449b7ceafdcffbe6f55d4b5e96032667">+467/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_diagnostics.py</strong><dd><code>Add extended PII field redaction tests for diagnostics</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/33/files#diff-cce28077bba940e579c5d82650c804358efaafef732856ccab3a41fbc3a25228">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_translations.py</strong><dd><code>Add translation coverage and keyset consistency regression tests</code></dd></td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/33/files#diff-d9a672881d7474830ca33650cb894b8b261793f04823dc93fe5f902d40b690b2">+331/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>hassfest.yml</strong><dd><code>Add branch filter to push trigger for hassfest validation</code></dd></td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/33/files#diff-b49043cd95e66c8410326eaf0adf7595f4140d4bb12cebbaf2a9a9d78bd54cf9">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lint.yml</strong><dd><code>Add branch filter to push trigger for linting workflow</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/33/files#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>validate.yml</strong><dd><code>Add branch filter to push trigger for HACS validation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/33/files#diff-a5c0f08bc43f53a0451cad4a4a2e435ce55ad34183350dfae5e4b2c7dca6360b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>manifest.json</strong><dd><code>Update integration version from 0.4.1 to 0.4.2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/33/files#diff-d7d310fbf33b630263734ddd50b73aa9908a7b336222ea7c340cf745a421e512">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

