### PR TITLE
Fix aiohttp import fallback and remove unused import

### DIFF
--- a/custom_components/airzoneclouddaikin/manifest.json
+++ b/custom_components/airzoneclouddaikin/manifest.json
@@ -3,7 +3,7 @@
   "name": "DKN Cloud for HASS",
   "codeowners": ["@eXPerience83"],
   "config_flow": true,
-  "dependencies": [],
+  "dependencies": ["persistent_notification"],
   "documentation": "https://github.com/eXPerience83/DKNCloud-HASS",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/eXPerience83/DKNCloud-HASS/issues",


### PR DESCRIPTION
### **User description**
### Motivation

- Prevent test collection failures when `aiohttp` is partially or differently installed by providing a robust fallback for missing symbols during import.
- Resolve a lint error by removing an unused `Callable` import surfaced by `ruff`.

### Description

- Remove the unused `Callable` import from `custom_components/airzoneclouddaikin/__init__.py`.
- Broaden the aiohttp import fallback in `tests/test_notifications.py` to catch `ImportError` as well as `ModuleNotFoundError` and provide minimal placeholder classes.
- Ensure the test module import path is preserved and the aiohttp fallback is registered on `sys.modules` so tests can run without the real `aiohttp` dependency.

### Testing

- Ran `black .` successfully to ensure consistent formatting.
- Ran `ruff check --fix --select I` and `ruff check` with no remaining issues.
- Ran `pytest` and all tests passed (`33 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963c996d92c8324ae8d2063e5b7aeaa)


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Remove unused `Callable` import from main module

- Refactor online banner cancellation to use per-device state

- Add `persistent_notification` to manifest dependencies

- Improve aiohttp import fallback to catch `ImportError`

- Add comprehensive tests for online banner transitions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Remove unused Callable import"] --> B["Refactor cancel_handles"]
  B --> C["Store online_cancel per device"]
  C --> D["Add persistent_notification dependency"]
  E["Improve aiohttp import fallback"] --> F["Catch ImportError and ModuleNotFoundError"]
  G["Add transition tests"] --> H["Test online banner cancellation"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Refactor online banner cancellation to per-device state</code>&nbsp; &nbsp; </dd></summary>
<hr>

custom_components/airzoneclouddaikin/__init__.py

<ul><li>Remove unused <code>Callable</code> import from <code>collections.abc</code><br> <li> Replace global <code>cancel_handles</code> list with per-device <code>online_cancel</code> state<br> <li> Add <code>online_cancel</code> field to device notification state dictionary<br> <li> Cancel previous online banner when transitioning offline or online <br>again<br> <li> Update unload logic to iterate through notify_state and cancel <br>per-device handlers</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/66/files#diff-0a2b04957b431594d35fbd3d53311cac51b252756aa7ecc03da2d3954c05aa56">+26/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_notifications.py</strong><dd><code>Improve aiohttp fallback and add transition tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_notifications.py

<ul><li>Broaden aiohttp import exception handling to catch both <code>ImportError</code> <br>and <code>ModuleNotFoundError</code><br> <li> Add test <code>test_online_banner_second_transition_cancels_previous</code> to <br>verify cancellation of previous online banner when device transitions <br>online again<br> <li> Add test <code>test_online_to_offline_cancels_online_banner</code> to verify online <br>banner is dismissed and cancelled when device goes offline</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/66/files#diff-8a215c82f1e5fc3d3fba8597e5939cdb6fab0316ea2587d0dedbee138be84548">+116/-1</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Add persistent_notification dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/airzoneclouddaikin/manifest.json

- Add `persistent_notification` to the `dependencies` array


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/66/files#diff-d7d310fbf33b630263734ddd50b73aa9908a7b336222ea7c340cf745a421e512">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

