### PR TITLE
Fix empty-body detection for unknown content length

### DIFF
--- a/custom_components/airzoneclouddaikin/airzone_api.py
+++ b/custom_components/airzoneclouddaikin/airzone_api.py
@@ -159,7 +159,7 @@ class AirzoneAPI:
                 resp.raise_for_status()
                 empty_body = resp.status == 204 or resp.content_length == 0
                 if resp.content_type == "application/json":
-                    if resp.status == 204 or resp.content_length == 0:
+                    if empty_body:
                         return None
                     return await resp.json()
                 if empty_body:

--- a/custom_components/airzoneclouddaikin/airzone_api.py
+++ b/custom_components/airzoneclouddaikin/airzone_api.py
@@ -157,7 +157,7 @@ class AirzoneAPI:
                 method, url, params=params, json=json, headers=headers, timeout=timeout
             ) as resp:
                 resp.raise_for_status()
-                empty_body = resp.status == 204 or resp.content_length in (0, None)
+                empty_body = resp.status == 204 or resp.content_length == 0
                 if resp.content_type == "application/json":
                     if resp.status == 204 or resp.content_length == 0:
                         return None


### PR DESCRIPTION
### **User description**
### Motivation
- Avoid treating `resp.content_length is None` (unknown length in `aiohttp`) as an empty response body, which could incorrectly skip JSON parsing for chunked/unknown-length responses.

### Description
- Replace `empty_body = resp.status == 204 or resp.content_length in (0, None)` with `empty_body = resp.status == 204 or resp.content_length == 0` in `custom_components/airzoneclouddaikin/airzone_api.py` so only HTTP 204 or `content_length == 0` are treated as empty.

### Testing
- Ran formatting and lint fixes with `black custom_components/airzoneclouddaikin/airzone_api.py` and `ruff check --fix --select I custom_components/airzoneclouddaikin/airzone_api.py` which passed, `ruff check custom_components/airzoneclouddaikin/airzone_api.py` passed, and `pytest -q` which passed (`48 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69859c39e24483249d05ab309c8d3489)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix empty-body detection to exclude unknown content lengths

- Prevent incorrect skipping of JSON parsing for chunked responses

- Only treat HTTP 204 or zero-length responses as empty


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["resp.content_length in 0, None"] -->|"Remove None check"| B["resp.content_length == 0"]
  C["HTTP 204 Status"] -->|"Keep as is"| B
  B -->|"Result"| D["Correct empty-body detection"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>airzone_api.py</strong><dd><code>Fix empty-body detection condition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/airzoneclouddaikin/airzone_api.py

<ul><li>Changed empty-body detection logic to exclude <code>None</code> content length<br> <li> Now only treats HTTP 204 status or zero content length as empty<br> <li> Prevents incorrect JSON parsing skips for chunked/unknown-length <br>responses</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/76/files#diff-b26005f00be0ac721843ac09ffe9b0e3fd9683bc1ab38d9047135f09c9a2f639">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

