### PR TITLE
Handle empty JSON responses in API client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 - Add dedicated handling for /events HTTP 423 ("machine not ready") with translations.
 - Avoid JSON parsing for empty application/json responses (e.g., HTTP 204).
+- Normalize backend power parsing in the power switch to avoid redundant P1 writes.
 - Ensure coordinator refresh coroutines are scheduled after sleep-expiry cleanup
   and post-write refresh delays.
 

--- a/custom_components/airzoneclouddaikin/airzone_api.py
+++ b/custom_components/airzoneclouddaikin/airzone_api.py
@@ -160,13 +160,11 @@ class AirzoneAPI:
                 resp.raise_for_status()
                 empty_body = resp.status == 204 or resp.content_length == 0
                 if resp.content_type == "application/json":
-                    if empty_body:
-                        return None
                     try:
                         return await resp.json()
                     except (JSONDecodeError, ValueError):
                         body = (await resp.text()).strip()
-                        if body == "":
+                        if not body:
                             return None
                         raise
                 if empty_body:

--- a/custom_components/airzoneclouddaikin/airzone_api.py
+++ b/custom_components/airzoneclouddaikin/airzone_api.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
+from json import JSONDecodeError
 from typing import Any
 
 from aiohttp import (
@@ -161,7 +162,13 @@ class AirzoneAPI:
                 if resp.content_type == "application/json":
                     if empty_body:
                         return None
-                    return await resp.json()
+                    try:
+                        return await resp.json()
+                    except (JSONDecodeError, ValueError):
+                        body = (await resp.text()).strip()
+                        if body == "":
+                            return None
+                        raise
                 if empty_body:
                     return ""
                 return await resp.text()

--- a/custom_components/airzoneclouddaikin/switch.py
+++ b/custom_components/airzoneclouddaikin/switch.py
@@ -86,8 +86,18 @@ class AirzonePowerSwitch(CoordinatorEntity[AirzoneCoordinator], SwitchEntity):
 
     def _backend_power_is_on(self) -> bool:
         """Return backend-reported power (ignore optimistic)."""
-        power = str(self._device.get("power", "0")).strip()
-        return power == "1"
+        power = self._device.get("power")
+        s = str(power).strip().lower()
+        if s in ("1", "on", "true", "yes"):
+            return True
+        if s in ("0", "off", "false", "no", "", "none"):
+            return False
+        if isinstance(power, bool):
+            return power
+        try:
+            return bool(int(power))
+        except Exception:  # noqa: BLE001
+            return False
 
     def _resolve_climate_entity_id(self) -> str | None:
         """Resolve the sibling climate entity via the entity registry."""

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -442,3 +442,19 @@ def test_send_event_logs_and_reraises_on_failure() -> None:
         assert "P1 failed" in str(err)
     else:  # pragma: no cover - safety net
         raise AssertionError("_send_event did not re-raise API error")
+
+
+def test_backend_power_is_on_normalizes_values() -> None:
+    """_backend_power_is_on should normalize common truthy/falsey values."""
+    truthy_values = [True, "true", "on", "yes", 1, "1", 2, "2"]
+    falsey_values = [False, "false", "off", "no", 0, "0", "", "none", None]
+
+    for value in truthy_values:
+        device = {"id": "dev1", "name": "Zone", "power": value}
+        entity, _hass = _make_switch(device)
+        assert entity._backend_power_is_on() is True
+
+    for value in falsey_values:
+        device = {"id": "dev1", "name": "Zone", "power": value}
+        entity, _hass = _make_switch(device)
+        assert entity._backend_power_is_on() is False


### PR DESCRIPTION
### **User description**
### Motivation
- Harden `AirzoneAPI._request()` in `custom_components/airzoneclouddaikin/airzone_api.py` against rare responses that advertise `application/json` but contain an empty body, avoiding JSON decode errors for whitespace-only responses while preserving real malformed-JSON errors.

### Description
- Wraped `await resp.json()` in a `try/except (JSONDecodeError, ValueError)` and on exception read `body = (await resp.text()).strip()` and return `None` when `body == ""`, otherwise re-raise the decode error.

### Testing
- Ran `pytest -q` which completed successfully (`48 passed`), and validated formatting/linting with `ruff check --fix --select I`, `ruff check`, and `black` which all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985a48aa4bc8324bc88a151b26dd67a)


___

### **PR Type**
Bug fix


___

### **Description**
- Handle empty JSON responses that advertise content-type but have empty body

- Catch JSONDecodeError and ValueError exceptions from resp.json()

- Return None for whitespace-only responses, re-raise actual malformed JSON

- Prevents JSON decode errors while preserving real parsing failures


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["resp.json() call"] --> B{"JSONDecodeError or ValueError?"}
  B -->|No| C["Return JSON data"]
  B -->|Yes| D["Read response text"]
  D --> E{"Body empty after strip?"}
  E -->|Yes| F["Return None"]
  E -->|No| G["Re-raise exception"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>airzone_api.py</strong><dd><code>Add error handling for empty JSON responses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/airzoneclouddaikin/airzone_api.py

<ul><li>Added import of <code>JSONDecodeError</code> from json module<br> <li> Wrapped <code>await resp.json()</code> in try/except block catching JSONDecodeError <br>and ValueError<br> <li> On exception, read response text and strip whitespace<br> <li> Return None for empty responses, otherwise re-raise the exception</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/DKNCloud-HASS/pull/77/files#diff-b26005f00be0ac721843ac09ffe9b0e3fd9683bc1ab38d9047135f09c9a2f639">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

