### PR TITLE
Fix orphan-safe PII cleanup, enable HACS zip_release packaging, and bump to 0.4.8

### DIFF
--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -1,5 +1,8 @@
 name: Package Test
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
 

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -1,0 +1,59 @@
+name: Package Test
+
+on:
+  workflow_dispatch:
+
+jobs:
+  package:
+    name: Build & validate ZIP
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build ZIP
+        shell: bash
+        run: |
+          set -euo pipefail
+          ZIP_NAME="airzoneclouddaikin.zip"
+          rm -f "${ZIP_NAME}"
+
+          cd "${GITHUB_WORKSPACE}/custom_components/airzoneclouddaikin"
+          zip -r "${GITHUB_WORKSPACE}/${ZIP_NAME}" ./ \
+            -x "*.pyc" \
+            -x "*/__pycache__/*" \
+            -x ".DS_Store"
+
+          cd "${GITHUB_WORKSPACE}"
+          ls -la "${ZIP_NAME}"
+
+      - name: Validate ZIP structure
+        shell: bash
+        run: |
+          set -euo pipefail
+          ZIP_NAME="airzoneclouddaikin.zip"
+
+          test -s "${ZIP_NAME}"
+
+          FILE_COUNT="$(unzip -Z1 "${ZIP_NAME}" | wc -l | tr -d ' ')"
+          if [ "${FILE_COUNT}" -eq 0 ]; then
+            echo "ZIP is empty"
+            exit 1
+          fi
+
+          if unzip -Z1 "${ZIP_NAME}" | grep -qE '^custom_components/'; then
+            echo "ZIP contains 'custom_components/' prefix (content must be in ZIP root)"
+            unzip -Z1 "${ZIP_NAME}" | head -n 200
+            exit 1
+          fi
+
+          unzip -Z1 "${ZIP_NAME}" | grep -qx '__init__.py'
+          unzip -Z1 "${ZIP_NAME}" | grep -qx 'manifest.json'
+          echo "ZIP validation OK"
+
+      - name: Upload ZIP artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: airzoneclouddaikin-zip
+          path: airzoneclouddaikin.zip
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build & upload ZIP to GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build ZIP
+        shell: bash
+        run: |
+          set -euo pipefail
+          ZIP_NAME="airzoneclouddaikin.zip"
+          rm -f "${ZIP_NAME}"
+
+          cd "${GITHUB_WORKSPACE}/custom_components/airzoneclouddaikin"
+          zip -r "${GITHUB_WORKSPACE}/${ZIP_NAME}" ./ \
+            -x "*.pyc" \
+            -x "*/__pycache__/*" \
+            -x ".DS_Store"
+
+          cd "${GITHUB_WORKSPACE}"
+          ls -la "${ZIP_NAME}"
+
+      - name: Validate ZIP structure
+        shell: bash
+        run: |
+          set -euo pipefail
+          ZIP_NAME="airzoneclouddaikin.zip"
+
+          test -s "${ZIP_NAME}"
+
+          FILE_COUNT="$(unzip -Z1 "${ZIP_NAME}" | wc -l | tr -d ' ')"
+          if [ "${FILE_COUNT}" -eq 0 ]; then
+            echo "ZIP is empty"
+            exit 1
+          fi
+
+          if unzip -Z1 "${ZIP_NAME}" | grep -qE '^custom_components/'; then
+            echo "ZIP contains 'custom_components/' prefix (content must be in ZIP root)"
+            unzip -Z1 "${ZIP_NAME}" | head -n 200
+            exit 1
+          fi
+
+          unzip -Z1 "${ZIP_NAME}" | grep -qx '__init__.py'
+          unzip -Z1 "${ZIP_NAME}" | grep -qx 'manifest.json'
+          echo "ZIP validation OK"
+
+      - name: Upload ZIP to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: airzoneclouddaikin.zip
+          overwrite_files: true
+          fail_on_unmatched_files: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+## [0.4.8] - 2026-03-03
+### Changed
+- Enable HACS `zip_release` packaging and add validated release ZIP workflows for
+  `airzoneclouddaikin.zip`.
+
+### Fixed
+- Remove orphaned PII sensor entities by unique-id suffix during opt-out cleanup,
+  even when coordinator device snapshots are empty.
+
 ## [0.4.7] - 2026-02-06
 ### Fixed
 - Add dedicated handling for /events HTTP 423 ("machine not ready") with translations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Changed
 - Enable HACS `zip_release` packaging and add validated release ZIP workflows for
   `airzoneclouddaikin.zip`.
+- Document dynamic climate `supported_features` behavior (DRY/FAN_ONLY/OFF
+  contract rationale) and lock the mode-feature matrix with regression tests.
 
 ### Fixed
 - Remove orphaned PII sensor entities by unique-id suffix during opt-out cleanup,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Fixed
 - Remove orphaned PII sensor entities by unique-id suffix during opt-out cleanup,
   even when coordinator device snapshots are empty.
+- Recompute HEAT_COOL capability in the options flow when the cached support flag
+  is unknown (`None`) and coordinator data later becomes available.
 
 ## [0.4.7] - 2026-02-06
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
   keep coordinator logs free of sensitive metadata.
 - Treat initial partial installation refreshes as update failures and retain the
   last successful per-installation snapshot on later transient errors.
+- Scope removed-device notification cleanup during partial refreshes so only
+  installations refreshed successfully are considered for removal handling.
+- Prune cached per-installation device maps when installations disappear from the
+  backend relations snapshot.
 
 ## [0.4.7] - 2026-02-06
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   cancelled installation requests immediately.
 - Avoid logging installation identifiers during per-installation fetch errors to
   keep coordinator logs free of sensitive metadata.
+- Treat initial partial installation refreshes as update failures and retain the
+  last successful per-installation snapshot on later transient errors.
 
 ## [0.4.7] - 2026-02-06
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   partial results when non-auth installation requests fail.
 - Preserve cancellation semantics during parallel device fetches by propagating
   cancelled installation requests immediately.
+- Avoid logging installation identifiers during per-installation fetch errors to
+  keep coordinator logs free of sensitive metadata.
 
 ## [0.4.7] - 2026-02-06
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   is unknown (`None`) and coordinator data later becomes available.
 - Parallelize per-installation device fetches during coordinator updates and keep
   partial results when non-auth installation requests fail.
+- Preserve cancellation semantics during parallel device fetches by propagating
+  cancelled installation requests immediately.
 
 ## [0.4.7] - 2026-02-06
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   even when coordinator device snapshots are empty.
 - Recompute HEAT_COOL capability in the options flow when the cached support flag
   is unknown (`None`) and coordinator data later becomes available.
+- Parallelize per-installation device fetches during coordinator updates and keep
+  partial results when non-auth installation requests fail.
 
 ## [0.4.7] - 2026-02-06
 ### Fixed

--- a/custom_components/airzoneclouddaikin/__init__.py
+++ b/custom_components/airzoneclouddaikin/__init__.py
@@ -232,7 +232,7 @@ async def _async_update_data(
         fetch_results = await asyncio.gather(*fetches, return_exceptions=True)
 
         auth_error = False
-        for inst_id, result in zip(installation_ids, fetch_results, strict=False):
+        for _inst_id, result in zip(installation_ids, fetch_results, strict=True):
             if isinstance(result, asyncio.CancelledError):
                 raise result
             if isinstance(result, ClientResponseError):
@@ -240,15 +240,13 @@ async def _async_update_data(
                     auth_error = True
                     continue
                 _LOGGER.warning(
-                    "Skipping installation %s due to HTTP %s while fetching devices.",
-                    inst_id,
+                    "Skipping one installation due to HTTP %s while fetching devices.",
                     result.status,
                 )
                 continue
             if isinstance(result, Exception):
                 _LOGGER.debug(
-                    "Skipping installation %s due to %s while fetching devices.",
-                    inst_id,
+                    "Skipping one installation due to %s while fetching devices.",
                     type(result).__name__,
                 )
                 continue
@@ -266,9 +264,8 @@ async def _async_update_data(
                 data[str(dev_id)] = dev
 
         if auth_error:
-            bucket = hass.data.setdefault(DOMAIN, {}).setdefault(entry.entry_id, {})
-            if not bucket.get("reauth_requested"):
-                bucket["reauth_requested"] = True
+            if not domain_bucket.get("reauth_requested"):
+                domain_bucket["reauth_requested"] = True
                 _LOGGER.warning("Authentication expired; opening reauth flow.")
                 hass.async_create_task(
                     hass.config_entries.flow.async_init(

--- a/custom_components/airzoneclouddaikin/__init__.py
+++ b/custom_components/airzoneclouddaikin/__init__.py
@@ -216,7 +216,7 @@ async def _async_update_data(
         data: dict[str, dict[str, Any]] = {}
         relations = await api.fetch_installations()
 
-        installation_ids: list[Any] = []
+        installation_ids: list[str] = []
         for rel in relations or []:
             inst_id: Any | None = None
             inst = rel.get("installation")
@@ -226,25 +226,43 @@ async def _async_update_data(
                 inst_id = rel.get("installation_id") or rel.get("id")
 
             if inst_id:
-                installation_ids.append(inst_id)
+                installation_ids.append(str(inst_id))
 
         fetches = [api.fetch_devices(inst_id) for inst_id in installation_ids]
         fetch_results = await asyncio.gather(*fetches, return_exceptions=True)
 
+        last_data: dict[str, dict[str, Any]] = domain_bucket.get("last_data", {})
+        if not isinstance(last_data, dict):
+            last_data = {}
+
+        device_installation_map: dict[str, str] = domain_bucket.setdefault(
+            "device_installation_map", {}
+        )
+        last_devices_by_inst: dict[str, set[str]] = domain_bucket.setdefault(
+            "last_devices_by_inst", {}
+        )
+
         auth_error = False
-        for _inst_id, result in zip(installation_ids, fetch_results, strict=True):
+        had_non_auth_install_errors = False
+        failed_installations: set[str] = set()
+
+        for inst_id, result in zip(installation_ids, fetch_results, strict=True):
             if isinstance(result, asyncio.CancelledError):
                 raise result
             if isinstance(result, ClientResponseError):
                 if result.status == 401:
                     auth_error = True
                     continue
+                had_non_auth_install_errors = True
+                failed_installations.add(inst_id)
                 _LOGGER.warning(
                     "Skipping one installation due to HTTP %s while fetching devices.",
                     result.status,
                 )
                 continue
             if isinstance(result, Exception):
+                had_non_auth_install_errors = True
+                failed_installations.add(inst_id)
                 _LOGGER.debug(
                     "Skipping one installation due to %s while fetching devices.",
                     type(result).__name__,
@@ -252,6 +270,7 @@ async def _async_update_data(
                 continue
 
             devices = result
+            inst_device_ids: set[str] = set()
             for dev in devices or []:
                 dev_id = dev.get("id")
                 if not dev_id:
@@ -261,7 +280,17 @@ async def _async_update_data(
                         dev["id"] = dev_id
                     else:
                         continue
-                data[str(dev_id)] = dev
+
+                dev_id_str = str(dev_id)
+                data[dev_id_str] = dev
+                inst_device_ids.add(dev_id_str)
+                device_installation_map[dev_id_str] = inst_id
+
+            previous_ids = set(last_devices_by_inst.get(inst_id, set()))
+            for stale_dev_id in previous_ids - inst_device_ids:
+                if device_installation_map.get(stale_dev_id) == inst_id:
+                    device_installation_map.pop(stale_dev_id, None)
+            last_devices_by_inst[inst_id] = inst_device_ids
 
         if auth_error:
             if not domain_bucket.get("reauth_requested"):
@@ -276,11 +305,29 @@ async def _async_update_data(
                 )
             raise UpdateFailed("Authentication required (401)")
 
+        had_prior_snapshot = bool(domain_bucket.get("has_successful_snapshot", False))
+        if had_non_auth_install_errors and not had_prior_snapshot:
+            domain_bucket["last_update_had_install_errors"] = True
+            raise UpdateFailed(
+                "Failed to update Airzone data: partial installation refresh"
+            )
+
+        if had_prior_snapshot and failed_installations:
+            for inst_id in failed_installations:
+                for dev_id in last_devices_by_inst.get(inst_id, set()):
+                    dev = last_data.get(dev_id)
+                    if dev is not None:
+                        data.setdefault(dev_id, dev)
+
+        domain_bucket["last_update_had_install_errors"] = had_non_auth_install_errors
+        domain_bucket["has_successful_snapshot"] = True
+        domain_bucket["last_data"] = dict(data)
         now = dt_util.utcnow()
         tracked_ids = set(sleep_tracking)
         active_ids = set(data)
-        for stale_id in tracked_ids - active_ids:
-            sleep_tracking.pop(stale_id, None)
+        if not had_non_auth_install_errors:
+            for stale_id in tracked_ids - active_ids:
+                sleep_tracking.pop(stale_id, None)
         for dev_id, dev in data.items():
             raw_scenary = str(dev.get("scenary") or "").strip().lower()
 
@@ -763,6 +810,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if raw_data is None:
             return
         if not getattr(coordinator, "last_update_success", True):
+            return
+        if bucket.get("last_update_had_install_errors"):
             return
 
         removed = set(notify_state) - set(data)

--- a/custom_components/airzoneclouddaikin/__init__.py
+++ b/custom_components/airzoneclouddaikin/__init__.py
@@ -233,6 +233,8 @@ async def _async_update_data(
 
         auth_error = False
         for inst_id, result in zip(installation_ids, fetch_results, strict=False):
+            if isinstance(result, asyncio.CancelledError):
+                raise result
             if isinstance(result, ClientResponseError):
                 if result.status == 401:
                     auth_error = True

--- a/custom_components/airzoneclouddaikin/__init__.py
+++ b/custom_components/airzoneclouddaikin/__init__.py
@@ -131,6 +131,24 @@ def _backend_power_is_off(device: dict[str, Any]) -> bool:
         return False
 
 
+def _request_reauth_once(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Trigger reauth flow once per entry and mark the entry bucket."""
+
+    bucket = hass.data.setdefault(DOMAIN, {}).setdefault(entry.entry_id, {})
+    if bucket.get("reauth_requested"):
+        return
+
+    bucket["reauth_requested"] = True
+    _LOGGER.warning("Authentication expired; opening reauth flow.")
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_REAUTH, "entry_id": entry.entry_id},
+            data=dict(entry.data),
+        )
+    )
+
+
 class AirzoneCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
     """Coordinator that aggregates installations and exposes device data.
 
@@ -293,16 +311,7 @@ async def _async_update_data(
             last_devices_by_inst[inst_id] = inst_device_ids
 
         if auth_error:
-            if not domain_bucket.get("reauth_requested"):
-                domain_bucket["reauth_requested"] = True
-                _LOGGER.warning("Authentication expired; opening reauth flow.")
-                hass.async_create_task(
-                    hass.config_entries.flow.async_init(
-                        DOMAIN,
-                        context={"source": SOURCE_REAUTH, "entry_id": entry.entry_id},
-                        data=dict(entry.data),
-                    )
-                )
+            _request_reauth_once(hass, entry)
             raise UpdateFailed("Authentication required (401)")
 
         had_prior_snapshot = bool(domain_bucket.get("has_successful_snapshot", False))
@@ -367,17 +376,7 @@ async def _async_update_data(
     except ClientResponseError as cre:
         status = cre.status
         if cre.status == 401:
-            bucket = hass.data.setdefault(DOMAIN, {}).setdefault(entry.entry_id, {})
-            if not bucket.get("reauth_requested"):
-                bucket["reauth_requested"] = True
-                _LOGGER.warning("Authentication expired; opening reauth flow.")
-                hass.async_create_task(
-                    hass.config_entries.flow.async_init(
-                        DOMAIN,
-                        context={"source": SOURCE_REAUTH, "entry_id": entry.entry_id},
-                        data=dict(entry.data),
-                    )
-                )
+            _request_reauth_once(hass, entry)
             raise UpdateFailed("Authentication required (401)") from None
         raise UpdateFailed(f"Failed to update Airzone data: HTTP {status}") from None
     except Exception as err:  # noqa: BLE001

--- a/custom_components/airzoneclouddaikin/__init__.py
+++ b/custom_components/airzoneclouddaikin/__init__.py
@@ -216,6 +216,7 @@ async def _async_update_data(
         data: dict[str, dict[str, Any]] = {}
         relations = await api.fetch_installations()
 
+        installation_ids: list[Any] = []
         for rel in relations or []:
             inst_id: Any | None = None
             inst = rel.get("installation")
@@ -224,10 +225,33 @@ async def _async_update_data(
             if inst_id is None:
                 inst_id = rel.get("installation_id") or rel.get("id")
 
-            if not inst_id:
+            if inst_id:
+                installation_ids.append(inst_id)
+
+        fetches = [api.fetch_devices(inst_id) for inst_id in installation_ids]
+        fetch_results = await asyncio.gather(*fetches, return_exceptions=True)
+
+        auth_error = False
+        for inst_id, result in zip(installation_ids, fetch_results, strict=False):
+            if isinstance(result, ClientResponseError):
+                if result.status == 401:
+                    auth_error = True
+                    continue
+                _LOGGER.warning(
+                    "Skipping installation %s due to HTTP %s while fetching devices.",
+                    inst_id,
+                    result.status,
+                )
+                continue
+            if isinstance(result, Exception):
+                _LOGGER.debug(
+                    "Skipping installation %s due to %s while fetching devices.",
+                    inst_id,
+                    type(result).__name__,
+                )
                 continue
 
-            devices = await api.fetch_devices(inst_id)
+            devices = result
             for dev in devices or []:
                 dev_id = dev.get("id")
                 if not dev_id:
@@ -238,6 +262,20 @@ async def _async_update_data(
                     else:
                         continue
                 data[str(dev_id)] = dev
+
+        if auth_error:
+            bucket = hass.data.setdefault(DOMAIN, {}).setdefault(entry.entry_id, {})
+            if not bucket.get("reauth_requested"):
+                bucket["reauth_requested"] = True
+                _LOGGER.warning("Authentication expired; opening reauth flow.")
+                hass.async_create_task(
+                    hass.config_entries.flow.async_init(
+                        DOMAIN,
+                        context={"source": SOURCE_REAUTH, "entry_id": entry.entry_id},
+                        data=dict(entry.data),
+                    )
+                )
+            raise UpdateFailed("Authentication required (401)")
 
         now = dt_util.utcnow()
         tracked_ids = set(sleep_tracking)
@@ -277,6 +315,8 @@ async def _async_update_data(
         return data
 
     except asyncio.CancelledError:
+        raise
+    except UpdateFailed:
         raise
     except ClientResponseError as cre:
         status = cre.status

--- a/custom_components/airzoneclouddaikin/__init__.py
+++ b/custom_components/airzoneclouddaikin/__init__.py
@@ -246,19 +246,31 @@ async def _async_update_data(
             if inst_id:
                 installation_ids.append(str(inst_id))
 
+        last_devices_by_inst: dict[str, set[str]] = domain_bucket.setdefault(
+            "last_devices_by_inst", {}
+        )
+        device_installation_map: dict[str, str] = domain_bucket.setdefault(
+            "device_installation_map", {}
+        )
+
+        current_installations = set(installation_ids)
+        stale_installations = [
+            inst_id
+            for inst_id in list(last_devices_by_inst)
+            if inst_id not in current_installations
+        ]
+        for stale_inst in stale_installations:
+            stale_ids = last_devices_by_inst.pop(stale_inst, set())
+            for stale_dev_id in stale_ids:
+                if device_installation_map.get(stale_dev_id) == stale_inst:
+                    device_installation_map.pop(stale_dev_id, None)
+
         fetches = [api.fetch_devices(inst_id) for inst_id in installation_ids]
         fetch_results = await asyncio.gather(*fetches, return_exceptions=True)
 
         last_data: dict[str, dict[str, Any]] = domain_bucket.get("last_data", {})
         if not isinstance(last_data, dict):
             last_data = {}
-
-        device_installation_map: dict[str, str] = domain_bucket.setdefault(
-            "device_installation_map", {}
-        )
-        last_devices_by_inst: dict[str, set[str]] = domain_bucket.setdefault(
-            "last_devices_by_inst", {}
-        )
 
         auth_error = False
         had_non_auth_install_errors = False
@@ -329,6 +341,7 @@ async def _async_update_data(
                         data.setdefault(dev_id, dev)
 
         domain_bucket["last_update_had_install_errors"] = had_non_auth_install_errors
+        domain_bucket["failed_installations_last_update"] = set(failed_installations)
         domain_bucket["has_successful_snapshot"] = True
         domain_bucket["last_data"] = dict(data)
         now = dt_util.utcnow()
@@ -810,10 +823,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             return
         if not getattr(coordinator, "last_update_success", True):
             return
-        if bucket.get("last_update_had_install_errors"):
-            return
 
         removed = set(notify_state) - set(data)
+        if bucket.get("last_update_had_install_errors"):
+            failed_installations = set(
+                bucket.get("failed_installations_last_update", set())
+            )
+            device_installation_map = bucket.get("device_installation_map", {})
+            if failed_installations and isinstance(device_installation_map, dict):
+                removed = {
+                    dev_id
+                    for dev_id in removed
+                    if device_installation_map.get(dev_id) not in failed_installations
+                }
         for dev_id in removed:
             st = notify_state.pop(dev_id, None)
             if st is None:

--- a/custom_components/airzoneclouddaikin/climate.py
+++ b/custom_components/airzoneclouddaikin/climate.py
@@ -675,7 +675,11 @@ class AirzoneClimate(CoordinatorEntity[AirzoneCoordinator], ClimateEntity):
             feats |= ClimateEntityFeature.FAN_MODE
         elif mode == HVACMode.FAN_ONLY:
             feats |= ClimateEntityFeature.FAN_MODE
-        # DRY/OFF: no temperature/fan controls
+        # Intentionally dynamic per the backend/UI contract documented in info.md:
+        # - DRY: setpoints are not meaningful and fan control is typically not exposed.
+        # - FAN_ONLY (including backend alias P2=8): fan control only; no target
+        #   temperature because P7/P8 setpoints do not apply.
+        # - OFF: no temperature/fan controls.
 
         # Presets always available (mapped to scenary)
         feats |= ClimateEntityFeature.PRESET_MODE

--- a/custom_components/airzoneclouddaikin/config_flow.py
+++ b/custom_components/airzoneclouddaikin/config_flow.py
@@ -288,7 +288,6 @@ class AirzoneOptionsFlow(config_entries.OptionsFlow):
                 return True
             if cached is False:
                 return False
-            return None
 
         coordinator = bucket.get("coordinator")
         data = getattr(coordinator, "data", None)
@@ -296,9 +295,14 @@ class AirzoneOptionsFlow(config_entries.OptionsFlow):
             return None
 
         try:
-            return any(device_supports_heat_cool(dev) for dev in data.values())
+            supports_heat_cool = any(
+                device_supports_heat_cool(dev) for dev in data.values()
+            )
         except Exception:  # noqa: BLE001
             return None
+
+        bucket["heat_cool_supported"] = supports_heat_cool
+        return supports_heat_cool
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/airzoneclouddaikin/manifest.json
+++ b/custom_components/airzoneclouddaikin/manifest.json
@@ -1,11 +1,15 @@
 {
   "domain": "airzoneclouddaikin",
   "name": "DKN Cloud for HASS",
-  "codeowners": ["@eXPerience83"],
+  "codeowners": [
+    "@eXPerience83"
+  ],
   "config_flow": true,
-  "dependencies": ["persistent_notification"],
+  "dependencies": [
+    "persistent_notification"
+  ],
   "documentation": "https://github.com/eXPerience83/DKNCloud-HASS",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/eXPerience83/DKNCloud-HASS/issues",
-  "version": "0.4.7"
+  "version": "0.4.8"
 }

--- a/custom_components/airzoneclouddaikin/manifest.json
+++ b/custom_components/airzoneclouddaikin/manifest.json
@@ -1,13 +1,9 @@
 {
   "domain": "airzoneclouddaikin",
   "name": "DKN Cloud for HASS",
-  "codeowners": [
-    "@eXPerience83"
-  ],
+  "codeowners": ["@eXPerience83"],
   "config_flow": true,
-  "dependencies": [
-    "persistent_notification"
-  ],
+  "dependencies": ["persistent_notification"],
   "documentation": "https://github.com/eXPerience83/DKNCloud-HASS",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/eXPerience83/DKNCloud-HASS/issues",

--- a/custom_components/airzoneclouddaikin/sensor.py
+++ b/custom_components/airzoneclouddaikin/sensor.py
@@ -281,15 +281,12 @@ async def async_setup_entry(hass, entry, async_add_entities):
     try:
         if not expose_pii:
             reg = er.async_get(hass)
-            known_device_ids = set((coordinator.data or {}).keys())
-            computed_pii_uids = {
-                f"{dev_id}_{attr}" for dev_id in known_device_ids for attr in PII_ATTRS
-            }
             for ent in er.async_entries_for_config_entry(reg, entry.entry_id):
                 if ent.domain != "sensor" or ent.platform != DOMAIN:
                     continue
                 uid = (ent.unique_id or "").strip()
-                if uid in computed_pii_uids:
+                attr = uid.rsplit("_", 1)[-1] if "_" in uid else ""
+                if attr in PII_ATTRS:
                     reg.async_remove(ent.entity_id)
     except Exception as exc:  # noqa: BLE001
         _LOGGER.debug("PII cleanup skipped due to registry error: %s", exc)

--- a/custom_components/airzoneclouddaikin/sensor.py
+++ b/custom_components/airzoneclouddaikin/sensor.py
@@ -285,8 +285,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 if ent.domain != "sensor" or ent.platform != DOMAIN:
                     continue
                 uid = (ent.unique_id or "").strip()
-                attr = uid.rsplit("_", 1)[-1] if "_" in uid else ""
-                if attr in PII_ATTRS:
+                if any(uid.endswith(f"_{attr}") for attr in PII_ATTRS):
                     reg.async_remove(ent.entity_id)
     except Exception as exc:  # noqa: BLE001
         _LOGGER.debug("PII cleanup skipped due to registry error: %s", exc)

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,7 @@
   "content_in_root": false,
   "render_readme": true,
   "homeassistant": "2025.2.0",
-  "hacs": "2.0.0"
+  "hacs": "2.0.0",
+  "zip_release": true,
+  "filename": "airzoneclouddaikin.zip"
 }

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -190,6 +190,9 @@ if not hasattr(climate_const_module, "ClimateEntityFeature"):
     class ClimateEntityFeature(IntFlag):
         TARGET_TEMPERATURE = 1
         FAN_MODE = 2
+        PRESET_MODE = 4
+        TURN_ON = 8
+        TURN_OFF = 16
 
     climate_const_module.ClimateEntityFeature = ClimateEntityFeature
 
@@ -291,6 +294,7 @@ climate_spec.loader.exec_module(climate_module_impl)
 
 AirzoneClimate = climate_module_impl.AirzoneClimate
 HVACMode = climate_const_module.HVACMode
+ClimateEntityFeature = climate_const_module.ClimateEntityFeature
 DOMAIN = climate_module_impl.DOMAIN
 
 
@@ -392,3 +396,47 @@ def test_heat_cool_retained_when_current_mode_loses_support() -> None:
         HVACMode.DRY,
         HVACMode.HEAT_COOL,
     ]
+
+
+def test_supported_features_matrix_by_hvac_mode() -> None:
+    """Freeze supported_features matrix by HVAC mode, including alias mode 8."""
+
+    base = (
+        ClimateEntityFeature.PRESET_MODE
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TURN_OFF
+    )
+
+    cases = [
+        ({"power": "0", "mode": "1"}, base),
+        ({"power": "1", "mode": "5"}, base),
+        (
+            {"power": "1", "mode": "1"},
+            base
+            | ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.FAN_MODE,
+        ),
+        (
+            {"power": "1", "mode": "2"},
+            base
+            | ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.FAN_MODE,
+        ),
+        (
+            {"power": "1", "mode": "4"},
+            base
+            | ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.FAN_MODE,
+        ),
+        ({"power": "1", "mode": "3"}, base | ClimateEntityFeature.FAN_MODE),
+        ({"power": "1", "mode": "8"}, base | ClimateEntityFeature.FAN_MODE),
+    ]
+
+    for snapshot, expected in cases:
+        device = {
+            "name": "Zone",
+            "modes": "11111",
+            **snapshot,
+        }
+        entity = _make_climate(device, heat_cool_opt_in=True)
+        assert entity.supported_features == expected

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -216,6 +216,11 @@ def _install_homeassistant_stubs() -> None:
     sys.modules["homeassistant.const"] = const_module
 
     core_module = types.ModuleType("homeassistant.core")
+
+    class HomeAssistant:  # pragma: no cover - stub only
+        pass
+
+    core_module.HomeAssistant = HomeAssistant
     sys.modules["homeassistant.core"] = core_module
 
     data_entry_flow_module = types.ModuleType("homeassistant.data_entry_flow")
@@ -248,6 +253,26 @@ def _install_homeassistant_stubs() -> None:
     helpers_module.config_validation = cv_module
     sys.modules["homeassistant.helpers.config_validation"] = cv_module
 
+    event_module = types.ModuleType("homeassistant.helpers.event")
+
+    def async_call_later(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    event_module.async_call_later = async_call_later
+    helpers_module.event = event_module
+    sys.modules["homeassistant.helpers.event"] = event_module
+
+    update_coordinator_module = types.ModuleType(
+        "homeassistant.helpers.update_coordinator"
+    )
+
+    class DataUpdateCoordinator:  # pragma: no cover - stub only
+        pass
+
+    update_coordinator_module.DataUpdateCoordinator = DataUpdateCoordinator
+    helpers_module.update_coordinator = update_coordinator_module
+    sys.modules["homeassistant.helpers.update_coordinator"] = update_coordinator_module
+
     ha_module.config_entries = config_entries_module
     ha_module.const = const_module
     ha_module.core = core_module
@@ -257,6 +282,17 @@ def _install_homeassistant_stubs() -> None:
 
 _install_voluptuous_stub()
 _install_homeassistant_stubs()
+
+custom_components_module = sys.modules.setdefault(
+    "custom_components", types.ModuleType("custom_components")
+)
+custom_components_module.__path__ = [str(ROOT / "custom_components")]
+
+airzone_package = sys.modules.setdefault(
+    "custom_components.airzoneclouddaikin",
+    types.ModuleType("custom_components.airzoneclouddaikin"),
+)
+airzone_package.__path__ = [str(ROOT / "custom_components" / "airzoneclouddaikin")]
 
 from homeassistant.config_entries import SOURCE_REAUTH  # type: ignore  # noqa: E402
 from homeassistant.const import (  # type: ignore  # noqa: E402
@@ -474,6 +510,39 @@ def test_options_flow_updates_options_and_preserves_hidden_keys(hass: HassStub) 
     assert new_options[CONF_SLEEP_TIMEOUT_ENABLED] is True
     assert new_options["user_token"] == "tok-123"
     assert new_options["hidden_key"] == "keep-me"
+
+
+def test_options_flow_recomputes_heat_cool_when_cached_none(hass: HassStub) -> None:
+    entry = ConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "user@example.com"},
+        options={
+            "user_token": "tok-123",
+            CONF_SCAN_INTERVAL: 10,
+            CONF_EXPOSE_PII: False,
+            CONF_ENABLE_HEAT_COOL: False,
+            CONF_SLEEP_TIMEOUT_ENABLED: False,
+        },
+        unique_id="user@example.com",
+    )
+    entry.add_to_hass(hass)
+
+    hass.data[DOMAIN] = {
+        entry.entry_id: {
+            "heat_cool_supported": None,
+            "coordinator": types.SimpleNamespace(
+                data={"dev1": {"modes": "0011"}, "dev2": {"modes": "1111"}}
+            ),
+        }
+    }
+
+    flow = AirzoneOptionsFlow(entry)
+    flow.hass = hass
+
+    result = flow._any_device_supports_heat_cool()
+
+    assert result is True
+    assert hass.data[DOMAIN][entry.entry_id]["heat_cool_supported"] is True
 
 
 def test_options_flow_defaults_sleep_timeout_when_missing(hass: HassStub) -> None:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -872,3 +872,88 @@ async def test_async_update_data_401_from_one_installation_triggers_reauth(
     bucket = hass.data[DOMAIN][entry.entry_id]
     assert bucket["reauth_requested"] is True
     assert flow_calls and flow_calls[0]["domain"] == DOMAIN
+
+
+@pytest.mark.asyncio
+async def test_removed_cleanup_keeps_failed_installation_devices_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hass = DummyHass()
+    entry = _make_entry()
+
+    monkeypatch.setattr(
+        integration.AirzoneAPI, "fetch_installations", AsyncMock(return_value=[])
+    )
+
+    await integration.async_setup_entry(hass, entry)
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    listener = coordinator._listeners[-1]
+
+    integration.persistent_notification.async_create = Mock()
+    integration.persistent_notification.async_dismiss = Mock()
+
+    bucket = hass.data[DOMAIN][entry.entry_id]
+    bucket["last_update_had_install_errors"] = True
+    bucket["failed_installations_last_update"] = {"inst-b"}
+    bucket["device_installation_map"] = {
+        "dev-a": "inst-a",
+        "dev-b": "inst-b",
+    }
+
+    cancel_a = Mock()
+    cancel_b = Mock()
+    notify_state = bucket["notify_state"]
+    notify_state["dev-a"] = {
+        "last": True,
+        "since_offline": None,
+        "notified": False,
+        "online_cancel": cancel_a,
+    }
+    notify_state["dev-b"] = {
+        "last": True,
+        "since_offline": None,
+        "notified": False,
+        "online_cancel": cancel_b,
+    }
+
+    coordinator.data = {}
+    listener()
+
+    assert "dev-a" not in notify_state
+    assert "dev-b" in notify_state
+    cancel_a.assert_called_once()
+    cancel_b.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_prunes_removed_installation_cache_state() -> None:
+    hass = DummyHass()
+    entry = _make_entry()
+
+    class DummyAPIInitial:
+        async def fetch_installations(self) -> list[dict[str, Any]]:
+            return [
+                {"installation": {"id": "inst-a"}},
+                {"installation": {"id": "inst-b"}},
+            ]
+
+        async def fetch_devices(self, inst_id: str) -> list[dict[str, Any]]:
+            if inst_id == "inst-a":
+                return [{"id": "dev-a", "name": "Unit A", "scenary": "home"}]
+            return [{"id": "dev-b", "name": "Unit B", "scenary": "home"}]
+
+    await integration._async_update_data(hass, entry, DummyAPIInitial())
+
+    class DummyAPIRemovedA:
+        async def fetch_installations(self) -> list[dict[str, Any]]:
+            return [{"installation": {"id": "inst-b"}}]
+
+        async def fetch_devices(self, _inst_id: str) -> list[dict[str, Any]]:
+            return [{"id": "dev-b", "name": "Unit B2", "scenary": "home"}]
+
+    data = await integration._async_update_data(hass, entry, DummyAPIRemovedA())
+    bucket = hass.data[DOMAIN][entry.entry_id]
+
+    assert set(data) == {"dev-b"}
+    assert "inst-a" not in bucket["last_devices_by_inst"]
+    assert "dev-a" not in bucket["device_installation_map"]

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -772,6 +772,24 @@ async def test_async_update_data_continues_after_transient_installation_error(
 
 
 @pytest.mark.asyncio
+async def test_async_update_data_propagates_cancelled_fetch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hass = DummyHass()
+    entry = _make_entry()
+
+    class DummyAPI:
+        async def fetch_installations(self) -> list[dict[str, Any]]:
+            return [{"installation": {"id": "inst-cancel"}}]
+
+        async def fetch_devices(self, _inst_id: str) -> list[dict[str, Any]]:
+            raise asyncio.CancelledError()
+
+    with pytest.raises(asyncio.CancelledError):
+        await integration._async_update_data(hass, entry, DummyAPI())
+
+
+@pytest.mark.asyncio
 async def test_async_update_data_401_from_one_installation_triggers_reauth(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import sys
 import types
 from datetime import datetime, timedelta, timezone
@@ -743,3 +744,74 @@ async def test_offline_notification_includes_datetime_connection_date(
     ]
     assert old.isoformat() in message
     assert "minutes ago" in message
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_continues_after_transient_installation_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hass = DummyHass()
+    entry = _make_entry()
+
+    class DummyAPI:
+        async def fetch_installations(self) -> list[dict[str, Any]]:
+            return [
+                {"installation": {"id": "inst-a"}},
+                {"installation": {"id": "inst-b"}},
+            ]
+
+        async def fetch_devices(self, inst_id: str) -> list[dict[str, Any]]:
+            if inst_id == "inst-a":
+                raise RuntimeError("temporary")
+            return [{"id": "dev-b", "name": "Unit B", "scenary": "home"}]
+
+    data = await integration._async_update_data(hass, entry, DummyAPI())
+
+    assert list(data) == ["dev-b"]
+    assert data["dev-b"]["name"] == "Unit B"
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_401_from_one_installation_triggers_reauth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hass = DummyHass()
+    entry = _make_entry()
+
+    flow_calls: list[dict[str, Any]] = []
+
+    async def _async_init(
+        domain: str, context: dict[str, Any], data: dict[str, Any]
+    ) -> dict[str, Any]:
+        flow_calls.append({"domain": domain, "context": context, "data": data})
+        return {"type": "flow"}
+
+    hass.config_entries.flow = types.SimpleNamespace(async_init=_async_init)
+    hass.async_create_task = lambda coro: asyncio.create_task(coro)
+
+    class FakeClientResponseError(Exception):
+        def __init__(self, status: int) -> None:
+            self.status = status
+
+    monkeypatch.setattr(integration, "ClientResponseError", FakeClientResponseError)
+
+    class DummyAPI:
+        async def fetch_installations(self) -> list[dict[str, Any]]:
+            return [
+                {"installation": {"id": "inst-401"}},
+                {"installation": {"id": "inst-ok"}},
+            ]
+
+        async def fetch_devices(self, inst_id: str) -> list[dict[str, Any]]:
+            if inst_id == "inst-401":
+                raise FakeClientResponseError(401)
+            return [{"id": "dev-ok", "name": "Unit OK", "scenary": "home"}]
+
+    with pytest.raises(UpdateFailed, match=r"Authentication required \(401\)"):
+        await integration._async_update_data(hass, entry, DummyAPI())
+
+    await asyncio.sleep(0)
+
+    bucket = hass.data[DOMAIN][entry.entry_id]
+    assert bucket["reauth_requested"] is True
+    assert flow_calls and flow_calls[0]["domain"] == DOMAIN

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -747,7 +747,7 @@ async def test_offline_notification_includes_datetime_connection_date(
 
 
 @pytest.mark.asyncio
-async def test_async_update_data_continues_after_transient_installation_error(
+async def test_async_update_data_raises_on_initial_partial_installation_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     hass = DummyHass()
@@ -765,10 +765,49 @@ async def test_async_update_data_continues_after_transient_installation_error(
                 raise RuntimeError("temporary")
             return [{"id": "dev-b", "name": "Unit B", "scenary": "home"}]
 
-    data = await integration._async_update_data(hass, entry, DummyAPI())
+    with pytest.raises(UpdateFailed, match="partial installation refresh"):
+        await integration._async_update_data(hass, entry, DummyAPI())
 
-    assert list(data) == ["dev-b"]
-    assert data["dev-b"]["name"] == "Unit B"
+
+@pytest.mark.asyncio
+async def test_async_update_data_preserves_failed_installation_from_previous_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hass = DummyHass()
+    entry = _make_entry()
+
+    class DummyAPIOk:
+        async def fetch_installations(self) -> list[dict[str, Any]]:
+            return [
+                {"installation": {"id": "inst-a"}},
+                {"installation": {"id": "inst-b"}},
+            ]
+
+        async def fetch_devices(self, inst_id: str) -> list[dict[str, Any]]:
+            if inst_id == "inst-a":
+                return [{"id": "dev-a", "name": "Unit A", "scenary": "home"}]
+            return [{"id": "dev-b", "name": "Unit B", "scenary": "home"}]
+
+    first = await integration._async_update_data(hass, entry, DummyAPIOk())
+    assert set(first) == {"dev-a", "dev-b"}
+
+    class DummyAPIPartial:
+        async def fetch_installations(self) -> list[dict[str, Any]]:
+            return [
+                {"installation": {"id": "inst-a"}},
+                {"installation": {"id": "inst-b"}},
+            ]
+
+        async def fetch_devices(self, inst_id: str) -> list[dict[str, Any]]:
+            if inst_id == "inst-a":
+                raise RuntimeError("temporary")
+            return [{"id": "dev-b", "name": "Unit B2", "scenary": "home"}]
+
+    second = await integration._async_update_data(hass, entry, DummyAPIPartial())
+
+    assert set(second) == {"dev-a", "dev-b"}
+    assert second["dev-a"]["name"] == "Unit A"
+    assert second["dev-b"]["name"] == "Unit B2"
 
 
 @pytest.mark.asyncio

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib.util
 import sys
 import types
@@ -12,174 +13,6 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-ha_module = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
-
-core_module = sys.modules.setdefault(
-    "homeassistant.core", types.ModuleType("homeassistant.core")
-)
-
-
-class HomeAssistant:  # pragma: no cover - stub only
-    def __init__(self) -> None:
-        self.data: dict[str, Any] = {}
-
-
-core_module.HomeAssistant = HomeAssistant
-
-components_module = sys.modules.setdefault(
-    "homeassistant.components", types.ModuleType("homeassistant.components")
-)
-
-sensor_component = sys.modules.setdefault(
-    "homeassistant.components.sensor",
-    types.ModuleType("homeassistant.components.sensor"),
-)
-
-
-class SensorEntity:  # pragma: no cover - stub only
-    pass
-
-
-class SensorDeviceClass:  # pragma: no cover - stub only
-    TEMPERATURE = "temperature"
-    TIMESTAMP = "timestamp"
-
-
-class SensorStateClass:  # pragma: no cover - stub only
-    MEASUREMENT = "measurement"
-
-
-sensor_component.SensorEntity = SensorEntity
-sensor_component.SensorDeviceClass = SensorDeviceClass
-sensor_component.SensorStateClass = SensorStateClass
-components_module.sensor = sensor_component
-ha_module.components = components_module
-
-const_module = sys.modules.setdefault(
-    "homeassistant.const", types.ModuleType("homeassistant.const")
-)
-const_module.UnitOfTemperature = types.SimpleNamespace(CELSIUS="°C")
-const_module.UnitOfTime = types.SimpleNamespace(MINUTES="min")
-
-helpers_module = sys.modules.setdefault(
-    "homeassistant.helpers", types.ModuleType("homeassistant.helpers")
-)
-
-entity_module = sys.modules.setdefault(
-    "homeassistant.helpers.entity", types.ModuleType("homeassistant.helpers.entity")
-)
-
-
-class EntityCategory:  # pragma: no cover - stub only
-    DIAGNOSTIC = "diagnostic"
-
-
-entity_module.EntityCategory = EntityCategory
-
-update_module = sys.modules.setdefault(
-    "homeassistant.helpers.update_coordinator",
-    types.ModuleType("homeassistant.helpers.update_coordinator"),
-)
-
-
-class CoordinatorEntity:  # pragma: no cover - stub only
-    def __init__(self, coordinator: Any) -> None:
-        self.coordinator = coordinator
-
-    def __class_getitem__(cls, _item: Any) -> type:
-        return cls
-
-
-class DataUpdateCoordinator:  # pragma: no cover - stub only
-    pass
-
-
-update_module.CoordinatorEntity = CoordinatorEntity
-update_module.DataUpdateCoordinator = DataUpdateCoordinator
-
-registry_module = sys.modules.setdefault(
-    "homeassistant.helpers.entity_registry",
-    types.ModuleType("homeassistant.helpers.entity_registry"),
-)
-
-
-class DeviceInfo(dict):  # pragma: no cover - stub only
-    """Dict-backed DeviceInfo stub."""
-
-
-device_registry_module = sys.modules.setdefault(
-    "homeassistant.helpers.device_registry",
-    types.ModuleType("homeassistant.helpers.device_registry"),
-)
-device_registry_module.CONNECTION_NETWORK_MAC = "mac"
-device_registry_module.DeviceInfo = DeviceInfo
-
-util_module = sys.modules.setdefault(
-    "homeassistant.util", types.ModuleType("homeassistant.util")
-)
-dt_module = sys.modules.setdefault(
-    "homeassistant.util.dt", types.ModuleType("homeassistant.util.dt")
-)
-
-
-def _noop_parse_datetime(_value: Any) -> None:
-    return None
-
-
-dt_module.parse_datetime = _noop_parse_datetime
-util_module.dt = dt_module
-
-event_module = sys.modules.setdefault(
-    "homeassistant.helpers.event", types.ModuleType("homeassistant.helpers.event")
-)
-
-
-def async_call_later(*_args: Any, **_kwargs: Any) -> None:  # pragma: no cover
-    return None
-
-
-event_module.async_call_later = async_call_later
-
-helpers_module.entity = entity_module
-helpers_module.update_coordinator = update_module
-helpers_module.entity_registry = registry_module
-helpers_module.device_registry = device_registry_module
-helpers_module.event = event_module
-ha_module.helpers = helpers_module
-
-custom_components_module = sys.modules.setdefault(
-    "custom_components", types.ModuleType("custom_components")
-)
-custom_components_module.__path__ = [str(ROOT / "custom_components")]
-
-airzone_package = sys.modules.setdefault(
-    "custom_components.airzoneclouddaikin",
-    types.ModuleType("custom_components.airzoneclouddaikin"),
-)
-airzone_package.__path__ = [str(ROOT / "custom_components" / "airzoneclouddaikin")]
-
-airzone_init_stub = types.ModuleType("custom_components.airzoneclouddaikin.__init__")
-
-
-class _AirzoneCoordinatorStub:
-    def __init__(self) -> None:
-        self.data: dict[str, dict[str, Any]] = {}
-
-
-airzone_init_stub.AirzoneCoordinator = _AirzoneCoordinatorStub
-sys.modules["custom_components.airzoneclouddaikin.__init__"] = airzone_init_stub
-
-sensor_spec = importlib.util.spec_from_file_location(
-    "custom_components.airzoneclouddaikin.sensor",
-    ROOT / "custom_components" / "airzoneclouddaikin" / "sensor.py",
-)
-assert sensor_spec and sensor_spec.loader
-sensor_module = importlib.util.module_from_spec(sensor_spec)
-sys.modules[sensor_spec.name] = sensor_module
-sensor_spec.loader.exec_module(sensor_module)
-
-DOMAIN = sensor_module.DOMAIN
-
 
 class DummyCoordinator:
     def __init__(self, data: dict[str, dict[str, Any]]) -> None:
@@ -188,16 +21,18 @@ class DummyCoordinator:
 
 class DummyRegistry:
     def __init__(self, entities: list[Any]) -> None:
-        self._entities = entities
         self.removed: list[str] = []
+        self.entities = entities
 
     def async_remove(self, entity_id: str) -> None:
         self.removed.append(entity_id)
 
 
 class DummyHass:
-    def __init__(self, coordinator: DummyCoordinator, entry_id: str) -> None:
-        self.data = {DOMAIN: {entry_id: {"coordinator": coordinator}}}
+    def __init__(
+        self, domain: str, coordinator: DummyCoordinator, entry_id: str
+    ) -> None:
+        self.data = {domain: {entry_id: {"coordinator": coordinator}}}
 
 
 class DummyEntry:
@@ -217,22 +52,214 @@ class RegistryEntity:
         self.platform = platform
 
 
+def _load_sensor_module_with_stubs() -> tuple[Any, Any]:
+    stubbed_modules = [
+        "homeassistant",
+        "homeassistant.core",
+        "homeassistant.components",
+        "homeassistant.components.sensor",
+        "homeassistant.const",
+        "homeassistant.helpers",
+        "homeassistant.helpers.entity",
+        "homeassistant.helpers.update_coordinator",
+        "homeassistant.helpers.entity_registry",
+        "homeassistant.helpers.device_registry",
+        "homeassistant.helpers.event",
+        "homeassistant.util",
+        "homeassistant.util.dt",
+        "custom_components",
+        "custom_components.airzoneclouddaikin",
+        "custom_components.airzoneclouddaikin.__init__",
+        "custom_components.airzoneclouddaikin.sensor",
+    ]
+    original_modules = {name: sys.modules.get(name) for name in stubbed_modules}
+
+    try:
+        ha_module = sys.modules.setdefault(
+            "homeassistant", types.ModuleType("homeassistant")
+        )
+
+        core_module = sys.modules.setdefault(
+            "homeassistant.core", types.ModuleType("homeassistant.core")
+        )
+
+        class HomeAssistant:  # pragma: no cover - stub only
+            def __init__(self) -> None:
+                self.data: dict[str, Any] = {}
+
+        core_module.HomeAssistant = HomeAssistant
+
+        components_module = sys.modules.setdefault(
+            "homeassistant.components", types.ModuleType("homeassistant.components")
+        )
+
+        sensor_component = sys.modules.setdefault(
+            "homeassistant.components.sensor",
+            types.ModuleType("homeassistant.components.sensor"),
+        )
+
+        class SensorEntity:  # pragma: no cover - stub only
+            pass
+
+        class SensorDeviceClass:  # pragma: no cover - stub only
+            TEMPERATURE = "temperature"
+            TIMESTAMP = "timestamp"
+
+        class SensorStateClass:  # pragma: no cover - stub only
+            MEASUREMENT = "measurement"
+
+        sensor_component.SensorEntity = SensorEntity
+        sensor_component.SensorDeviceClass = SensorDeviceClass
+        sensor_component.SensorStateClass = SensorStateClass
+        components_module.sensor = sensor_component
+        ha_module.components = components_module
+
+        const_module = sys.modules.setdefault(
+            "homeassistant.const", types.ModuleType("homeassistant.const")
+        )
+        const_module.UnitOfTemperature = types.SimpleNamespace(CELSIUS="°C")
+        const_module.UnitOfTime = types.SimpleNamespace(MINUTES="min")
+
+        helpers_module = sys.modules.setdefault(
+            "homeassistant.helpers", types.ModuleType("homeassistant.helpers")
+        )
+
+        entity_module = sys.modules.setdefault(
+            "homeassistant.helpers.entity",
+            types.ModuleType("homeassistant.helpers.entity"),
+        )
+
+        class EntityCategory:  # pragma: no cover - stub only
+            DIAGNOSTIC = "diagnostic"
+
+        entity_module.EntityCategory = EntityCategory
+
+        update_module = sys.modules.setdefault(
+            "homeassistant.helpers.update_coordinator",
+            types.ModuleType("homeassistant.helpers.update_coordinator"),
+        )
+
+        class CoordinatorEntity:  # pragma: no cover - stub only
+            def __init__(self, coordinator: Any) -> None:
+                self.coordinator = coordinator
+
+            def __class_getitem__(cls, _item: Any) -> type:
+                return cls
+
+        class DataUpdateCoordinator:  # pragma: no cover - stub only
+            pass
+
+        update_module.CoordinatorEntity = CoordinatorEntity
+        update_module.DataUpdateCoordinator = DataUpdateCoordinator
+
+        registry_module = sys.modules.setdefault(
+            "homeassistant.helpers.entity_registry",
+            types.ModuleType("homeassistant.helpers.entity_registry"),
+        )
+
+        class DeviceInfo(dict):  # pragma: no cover - stub only
+            """Dict-backed DeviceInfo stub."""
+
+        device_registry_module = sys.modules.setdefault(
+            "homeassistant.helpers.device_registry",
+            types.ModuleType("homeassistant.helpers.device_registry"),
+        )
+        device_registry_module.CONNECTION_NETWORK_MAC = "mac"
+        device_registry_module.DeviceInfo = DeviceInfo
+
+        event_module = sys.modules.setdefault(
+            "homeassistant.helpers.event",
+            types.ModuleType("homeassistant.helpers.event"),
+        )
+
+        def async_call_later(*_args: Any, **_kwargs: Any) -> None:  # pragma: no cover
+            return None
+
+        event_module.async_call_later = async_call_later
+
+        util_module = sys.modules.setdefault(
+            "homeassistant.util", types.ModuleType("homeassistant.util")
+        )
+        dt_module = sys.modules.setdefault(
+            "homeassistant.util.dt", types.ModuleType("homeassistant.util.dt")
+        )
+
+        def _noop_parse_datetime(_value: Any) -> None:
+            return None
+
+        dt_module.parse_datetime = _noop_parse_datetime
+        dt_module.as_utc = lambda val: val
+        dt_module.get_default_time_zone = lambda: None
+        util_module.dt = dt_module
+
+        helpers_module.entity = entity_module
+        helpers_module.update_coordinator = update_module
+        helpers_module.entity_registry = registry_module
+        helpers_module.device_registry = device_registry_module
+        helpers_module.event = event_module
+        ha_module.helpers = helpers_module
+
+        custom_components_module = sys.modules.setdefault(
+            "custom_components", types.ModuleType("custom_components")
+        )
+        custom_components_module.__path__ = [str(ROOT / "custom_components")]
+
+        airzone_package = sys.modules.setdefault(
+            "custom_components.airzoneclouddaikin",
+            types.ModuleType("custom_components.airzoneclouddaikin"),
+        )
+        airzone_package.__path__ = [
+            str(ROOT / "custom_components" / "airzoneclouddaikin")
+        ]
+
+        airzone_init_stub = types.ModuleType(
+            "custom_components.airzoneclouddaikin.__init__"
+        )
+
+        class _AirzoneCoordinatorStub:
+            def __init__(self) -> None:
+                self.data: dict[str, dict[str, Any]] = {}
+
+        airzone_init_stub.AirzoneCoordinator = _AirzoneCoordinatorStub
+        sys.modules["custom_components.airzoneclouddaikin.__init__"] = airzone_init_stub
+
+        sensor_spec = importlib.util.spec_from_file_location(
+            "custom_components.airzoneclouddaikin.sensor",
+            ROOT / "custom_components" / "airzoneclouddaikin" / "sensor.py",
+        )
+        assert sensor_spec and sensor_spec.loader
+        sensor_module = importlib.util.module_from_spec(sensor_spec)
+        sys.modules[sensor_spec.name] = sensor_module
+        sensor_spec.loader.exec_module(sensor_module)
+
+        return sensor_module, registry_module
+    finally:
+        for name, original in original_modules.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
 def test_async_setup_entry_removes_orphan_pii_entities_only() -> None:
     """Opt-out cleanup removes orphan PII entities even if coordinator snapshot is empty."""
 
+    sensor_module, registry_module = _load_sensor_module_with_stubs()
+    domain = sensor_module.DOMAIN
     entry_id = "entry-1"
+
     coordinator = DummyCoordinator(data={})
-    hass = DummyHass(coordinator, entry_id)
+    hass = DummyHass(domain, coordinator, entry_id)
     entry = DummyEntry(entry_id)
 
     registry_entities = [
-        RegistryEntity("sensor.olddevice_mac", "olddevice_mac", "sensor", DOMAIN),
+        RegistryEntity("sensor.olddevice_mac", "olddevice_mac", "sensor", domain),
         RegistryEntity(
-            "sensor.olddevice_local_temp", "olddevice_local_temp", "sensor", DOMAIN
+            "sensor.olddevice_local_temp", "olddevice_local_temp", "sensor", domain
         ),
         RegistryEntity("sensor.external_mac", "other_mac", "sensor", "other_platform"),
         RegistryEntity(
-            "binary_sensor.olddevice_mac", "olddevice_mac", "binary_sensor", DOMAIN
+            "binary_sensor.olddevice_mac", "olddevice_mac", "binary_sensor", domain
         ),
     ]
     reg = DummyRegistry(registry_entities)
@@ -246,8 +273,6 @@ def test_async_setup_entry_removes_orphan_pii_entities_only() -> None:
 
     async def _run_setup() -> None:
         await sensor_module.async_setup_entry(hass, entry, added_entities.extend)
-
-    import asyncio
 
     asyncio.run(_run_setup())
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -255,6 +255,12 @@ def test_async_setup_entry_removes_orphan_pii_entities_only() -> None:
     registry_entities = [
         RegistryEntity("sensor.olddevice_mac", "olddevice_mac", "sensor", domain),
         RegistryEntity(
+            "sensor.olddevice_installation_id",
+            "olddevice_installation_id",
+            "sensor",
+            domain,
+        ),
+        RegistryEntity(
             "sensor.olddevice_local_temp", "olddevice_local_temp", "sensor", domain
         ),
         RegistryEntity("sensor.external_mac", "other_mac", "sensor", "other_platform"),
@@ -276,5 +282,8 @@ def test_async_setup_entry_removes_orphan_pii_entities_only() -> None:
 
     asyncio.run(_run_setup())
 
-    assert reg.removed == ["sensor.olddevice_mac"]
+    assert reg.removed == [
+        "sensor.olddevice_mac",
+        "sensor.olddevice_installation_id",
+    ]
     assert added_entities == []

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,255 @@
+"""Tests for sensor setup behaviors."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+ha_module = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
+
+core_module = sys.modules.setdefault(
+    "homeassistant.core", types.ModuleType("homeassistant.core")
+)
+
+
+class HomeAssistant:  # pragma: no cover - stub only
+    def __init__(self) -> None:
+        self.data: dict[str, Any] = {}
+
+
+core_module.HomeAssistant = HomeAssistant
+
+components_module = sys.modules.setdefault(
+    "homeassistant.components", types.ModuleType("homeassistant.components")
+)
+
+sensor_component = sys.modules.setdefault(
+    "homeassistant.components.sensor",
+    types.ModuleType("homeassistant.components.sensor"),
+)
+
+
+class SensorEntity:  # pragma: no cover - stub only
+    pass
+
+
+class SensorDeviceClass:  # pragma: no cover - stub only
+    TEMPERATURE = "temperature"
+    TIMESTAMP = "timestamp"
+
+
+class SensorStateClass:  # pragma: no cover - stub only
+    MEASUREMENT = "measurement"
+
+
+sensor_component.SensorEntity = SensorEntity
+sensor_component.SensorDeviceClass = SensorDeviceClass
+sensor_component.SensorStateClass = SensorStateClass
+components_module.sensor = sensor_component
+ha_module.components = components_module
+
+const_module = sys.modules.setdefault(
+    "homeassistant.const", types.ModuleType("homeassistant.const")
+)
+const_module.UnitOfTemperature = types.SimpleNamespace(CELSIUS="°C")
+const_module.UnitOfTime = types.SimpleNamespace(MINUTES="min")
+
+helpers_module = sys.modules.setdefault(
+    "homeassistant.helpers", types.ModuleType("homeassistant.helpers")
+)
+
+entity_module = sys.modules.setdefault(
+    "homeassistant.helpers.entity", types.ModuleType("homeassistant.helpers.entity")
+)
+
+
+class EntityCategory:  # pragma: no cover - stub only
+    DIAGNOSTIC = "diagnostic"
+
+
+entity_module.EntityCategory = EntityCategory
+
+update_module = sys.modules.setdefault(
+    "homeassistant.helpers.update_coordinator",
+    types.ModuleType("homeassistant.helpers.update_coordinator"),
+)
+
+
+class CoordinatorEntity:  # pragma: no cover - stub only
+    def __init__(self, coordinator: Any) -> None:
+        self.coordinator = coordinator
+
+    def __class_getitem__(cls, _item: Any) -> type:
+        return cls
+
+
+class DataUpdateCoordinator:  # pragma: no cover - stub only
+    pass
+
+
+update_module.CoordinatorEntity = CoordinatorEntity
+update_module.DataUpdateCoordinator = DataUpdateCoordinator
+
+registry_module = sys.modules.setdefault(
+    "homeassistant.helpers.entity_registry",
+    types.ModuleType("homeassistant.helpers.entity_registry"),
+)
+
+
+class DeviceInfo(dict):  # pragma: no cover - stub only
+    """Dict-backed DeviceInfo stub."""
+
+
+device_registry_module = sys.modules.setdefault(
+    "homeassistant.helpers.device_registry",
+    types.ModuleType("homeassistant.helpers.device_registry"),
+)
+device_registry_module.CONNECTION_NETWORK_MAC = "mac"
+device_registry_module.DeviceInfo = DeviceInfo
+
+util_module = sys.modules.setdefault(
+    "homeassistant.util", types.ModuleType("homeassistant.util")
+)
+dt_module = sys.modules.setdefault(
+    "homeassistant.util.dt", types.ModuleType("homeassistant.util.dt")
+)
+
+
+def _noop_parse_datetime(_value: Any) -> None:
+    return None
+
+
+dt_module.parse_datetime = _noop_parse_datetime
+util_module.dt = dt_module
+
+event_module = sys.modules.setdefault(
+    "homeassistant.helpers.event", types.ModuleType("homeassistant.helpers.event")
+)
+
+
+def async_call_later(*_args: Any, **_kwargs: Any) -> None:  # pragma: no cover
+    return None
+
+
+event_module.async_call_later = async_call_later
+
+helpers_module.entity = entity_module
+helpers_module.update_coordinator = update_module
+helpers_module.entity_registry = registry_module
+helpers_module.device_registry = device_registry_module
+helpers_module.event = event_module
+ha_module.helpers = helpers_module
+
+custom_components_module = sys.modules.setdefault(
+    "custom_components", types.ModuleType("custom_components")
+)
+custom_components_module.__path__ = [str(ROOT / "custom_components")]
+
+airzone_package = sys.modules.setdefault(
+    "custom_components.airzoneclouddaikin",
+    types.ModuleType("custom_components.airzoneclouddaikin"),
+)
+airzone_package.__path__ = [str(ROOT / "custom_components" / "airzoneclouddaikin")]
+
+airzone_init_stub = types.ModuleType("custom_components.airzoneclouddaikin.__init__")
+
+
+class _AirzoneCoordinatorStub:
+    def __init__(self) -> None:
+        self.data: dict[str, dict[str, Any]] = {}
+
+
+airzone_init_stub.AirzoneCoordinator = _AirzoneCoordinatorStub
+sys.modules["custom_components.airzoneclouddaikin.__init__"] = airzone_init_stub
+
+sensor_spec = importlib.util.spec_from_file_location(
+    "custom_components.airzoneclouddaikin.sensor",
+    ROOT / "custom_components" / "airzoneclouddaikin" / "sensor.py",
+)
+assert sensor_spec and sensor_spec.loader
+sensor_module = importlib.util.module_from_spec(sensor_spec)
+sys.modules[sensor_spec.name] = sensor_module
+sensor_spec.loader.exec_module(sensor_module)
+
+DOMAIN = sensor_module.DOMAIN
+
+
+class DummyCoordinator:
+    def __init__(self, data: dict[str, dict[str, Any]]) -> None:
+        self.data = data
+
+
+class DummyRegistry:
+    def __init__(self, entities: list[Any]) -> None:
+        self._entities = entities
+        self.removed: list[str] = []
+
+    def async_remove(self, entity_id: str) -> None:
+        self.removed.append(entity_id)
+
+
+class DummyHass:
+    def __init__(self, coordinator: DummyCoordinator, entry_id: str) -> None:
+        self.data = {DOMAIN: {entry_id: {"coordinator": coordinator}}}
+
+
+class DummyEntry:
+    def __init__(self, entry_id: str) -> None:
+        self.entry_id = entry_id
+        self.options = {"expose_pii_identifiers": False}
+        self.data = {}
+
+
+class RegistryEntity:
+    def __init__(
+        self, entity_id: str, unique_id: str, domain: str, platform: str
+    ) -> None:
+        self.entity_id = entity_id
+        self.unique_id = unique_id
+        self.domain = domain
+        self.platform = platform
+
+
+def test_async_setup_entry_removes_orphan_pii_entities_only() -> None:
+    """Opt-out cleanup removes orphan PII entities even if coordinator snapshot is empty."""
+
+    entry_id = "entry-1"
+    coordinator = DummyCoordinator(data={})
+    hass = DummyHass(coordinator, entry_id)
+    entry = DummyEntry(entry_id)
+
+    registry_entities = [
+        RegistryEntity("sensor.olddevice_mac", "olddevice_mac", "sensor", DOMAIN),
+        RegistryEntity(
+            "sensor.olddevice_local_temp", "olddevice_local_temp", "sensor", DOMAIN
+        ),
+        RegistryEntity("sensor.external_mac", "other_mac", "sensor", "other_platform"),
+        RegistryEntity(
+            "binary_sensor.olddevice_mac", "olddevice_mac", "binary_sensor", DOMAIN
+        ),
+    ]
+    reg = DummyRegistry(registry_entities)
+
+    registry_module.async_get = lambda _hass: reg
+    registry_module.async_entries_for_config_entry = (
+        lambda _reg, _entry_id: registry_entities
+    )
+
+    added_entities: list[Any] = []
+
+    async def _run_setup() -> None:
+        await sensor_module.async_setup_entry(hass, entry, added_entities.extend)
+
+    import asyncio
+
+    asyncio.run(_run_setup())
+
+    assert reg.removed == ["sensor.olddevice_mac"]
+    assert added_entities == []


### PR DESCRIPTION
### Motivation
- Ensure opting out of PII exposure definitively removes all PII sensor entities from the Home Assistant Entity Registry, including orphaned entries that no longer appear in coordinator snapshots. 
- Provide a HACS-compatible ZIP release artifact so HACS and GitHub releases can publish/download a validated `airzoneclouddaikin.zip` package. 
- Ship the above changes as a new integration version with a short changelog entry.

### Description
- Replace computed-device-based PII cleanup with pattern-based detection in `async_setup_entry()` by inspecting each registry entry `unique_id` and removing entries whose suffix (obtained with `uid.rsplit("_", 1)`) is in `PII_ATTRS` (e.g., `_mac`, `_pin`, `_installation_id`) in `custom_components/airzoneclouddaikin/sensor.py`.
- Add a regression test `tests/test_sensor.py` that provides lightweight Home Assistant stubs and a fake registry to simulate an empty `coordinator.data` snapshot and verifies only the orphan PII sensor is removed while non-PII and other platform/domain entries remain.
- Enable HACS ZIP releases by updating `hacs.json` with `"zip_release": true` and `"filename": "airzoneclouddaikin.zip"` and add GitHub Actions workflows: `.github/workflows/package-test.yml` (manual package build + validation + artifact) and `.github/workflows/release.yml` (on-release build + validation + upload to the GitHub Release).
- Bump integration metadata version to `0.4.8` in `custom_components/airzoneclouddaikin/manifest.json` and add a brief `0.4.8` entry to `CHANGELOG.md` describing the fix and packaging change.

### Testing
- Ran `ruff check --fix --select I custom_components/airzoneclouddaikin/sensor.py tests/test_sensor.py` and `ruff check` and the import/order checks passed.
- Ran `black custom_components/airzoneclouddaikin/sensor.py tests/test_sensor.py` for formatting.
- Executed `pytest -q tests/test_sensor.py` and the new test passed: `1 passed`.
- Added CI workflows (`package-test.yml` and `release.yml`) that build and validate `airzoneclouddaikin.zip`; these workflows are included for CI/release validation (not executed in the local test run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a717c1c0b08324929e21bf3b92a9cf)