### PR TITLE
Add local testing secrets scaffold

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -50,7 +50,10 @@ reviews:
       - "github-actions[bot]"
 
   path_filters:
-    - "!secrets/**"
+    - "!secrets/*.env"
+    - "!secrets/*.local"
+    - "!secrets/*.json"
+    - "!secrets/*.log"
     - "!**/*.zip"
     - "!**/*.png"
     - "!**/*.jpg"
@@ -76,8 +79,9 @@ reviews:
         Review Python changes with that baseline in mind:
         - Do not request compatibility with Python 3.13 or older.
         - Do not propose syntax rewrites only for old Python compatibility.
-        - Do flag invalid Python syntax if present; Python 3 still requires
-          multi-exception handlers to use `except (A, B):`, not `except A, B:`.
+        - Follow Python 3.14+ syntax: `except A, B:` (without `as`) is valid
+          per PEP 758; `except A, B as e:` is still invalid and must be
+          written as `except (A, B) as e:`.
         - Prefer focused fixes over broad rewrites.
 
     - path: "custom_components/airzoneclouddaikin/**/*.py"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -50,6 +50,8 @@ reviews:
       - "github-actions[bot]"
 
   path_filters:
+    - "!secrets/.env"
+    - "!secrets/.*.env"
     - "!secrets/*.env"
     - "!secrets/*.local"
     - "!secrets/*.json"

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,16 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Local testing secrets (secrets/)
+#   Protect real credential files but keep tracked templates reviewable
+secrets/.env
+secrets/*.env
+secrets/*.local
+secrets/*.json
+secrets/*.log
+
+# Root-level env files
+.env
+.env.*
+!.env.example

--- a/secrets/.env.example
+++ b/secrets/.env.example
@@ -1,0 +1,13 @@
+# DKN Cloud — local testing secrets
+#
+# Copy this file to .env and fill in your real Airzone Cloud credentials.
+# Never commit .env or any file matching secrets/*.env, secrets/*.local,
+# secrets/*.json, or secrets/*.log.
+#
+# Usage (from repo root):
+#   export $(cat secrets/.env | xargs)
+#   pytest -q  # or run any local tool that reads these env vars
+
+AIRZONE_EMAIL=user@example.com
+AIRZONE_PASSWORD=your-password-here
+AIRZONE_TOKEN=

--- a/secrets/.env.example
+++ b/secrets/.env.example
@@ -1,13 +1,12 @@
-# DKN Cloud — local testing secrets
+# Copy this file to secrets/.env and fill locally.
+# Never commit secrets/.env.
 #
-# Copy this file to .env and fill in your real Airzone Cloud credentials.
-# Never commit .env or any file matching secrets/*.env, secrets/*.local,
-# secrets/*.json, or secrets/*.log.
-#
-# Usage (from repo root):
-#   export $(cat secrets/.env | xargs)
-#   pytest -q  # or run any local tool that reads these env vars
+# Source (from repo root):
+#   set -a && . secrets/.env && set +a
 
-AIRZONE_EMAIL=user@example.com
-AIRZONE_PASSWORD=your-password-here
-AIRZONE_TOKEN=
+AIRZONE_USERNAME=
+AIRZONE_PASSWORD=
+
+# Optional, for targeted manual control tests
+AIRZONE_INSTALLATION_ID=
+AIRZONE_DEVICE_ID=

--- a/secrets/.gitignore
+++ b/secrets/.gitignore
@@ -1,0 +1,7 @@
+# Protect all local secrets by default
+
+*
+.*
+!.gitignore
+!.env.example
+!README.md

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -1,0 +1,43 @@
+# Local testing secrets
+
+This directory holds local-only credentials for manual testing of the DKN
+Cloud integration against a real Airzone Cloud account.
+
+## Files
+
+| File            | Tracked | Purpose                       |
+| --------------- | ------- | ----------------------------- |
+| `.env.example`  | Yes     | Template with placeholder values |
+| `.env`          | No      | Your real credentials (gitignored) |
+| `.gitignore`    | Yes     | Prevents accidental commits of secrets |
+
+## Setup
+
+```bash
+cp secrets/.env.example secrets/.env
+# Edit secrets/.env with your real Airzone Cloud credentials
+```
+
+## Safety
+
+- **Never commit** `.env`, `*.env`, `*.local`, `*.json`, or `*.log` files inside
+  this directory.
+- The root `.gitignore` and `secrets/.gitignore` both protect against accidental
+  commits.
+- CI **must never** depend on `secrets/.env` or real Airzone credentials. All
+  CI tests use mocked API responses.
+
+## Usage
+
+Source the env file before running tests or tools locally:
+
+```bash
+export $(cat secrets/.env | xargs)
+pytest -q
+```
+
+Or prefix individual commands:
+
+```bash
+env $(cat secrets/.env | xargs) pytest tests/test_airzone_api.py -q
+```

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -1,43 +1,34 @@
-# Local testing secrets
+# Local secrets
 
-This directory holds local-only credentials for manual testing of the DKN
-Cloud integration against a real Airzone Cloud account.
+This folder is for local/manual testing only.
 
-## Files
+Tracked files:
+- .gitignore
+- .env.example
+- README.md
 
-| File            | Tracked | Purpose                       |
-| --------------- | ------- | ----------------------------- |
-| `.env.example`  | Yes     | Template with placeholder values |
-| `.env`          | No      | Your real credentials (gitignored) |
-| `.gitignore`    | Yes     | Prevents accidental commits of secrets |
+Local-only files:
+- .env
+- *.env
+- *.local
+- *.json
+- *.log
 
-## Setup
-
-```bash
-cp secrets/.env.example secrets/.env
-# Edit secrets/.env with your real Airzone Cloud credentials
-```
-
-## Safety
-
-- **Never commit** `.env`, `*.env`, `*.local`, `*.json`, or `*.log` files inside
-  this directory.
-- The root `.gitignore` and `secrets/.gitignore` both protect against accidental
-  commits.
-- CI **must never** depend on `secrets/.env` or real Airzone credentials. All
-  CI tests use mocked API responses.
+Never commit real Airzone credentials, tokens, full API URLs, request logs, or raw payload captures containing credentials.
 
 ## Usage
 
-Source the env file before running tests or tools locally:
+Source the env file before running tools:
 
 ```bash
-export $(cat secrets/.env | xargs)
+set -a
+. secrets/.env
+set +a
 pytest -q
 ```
 
-Or prefix individual commands:
+One-liner for ad-hoc commands:
 
 ```bash
-env $(cat secrets/.env | xargs) pytest tests/test_airzone_api.py -q
+(set -a && . secrets/.env && pytest tests/test_airzone_api.py -q)
 ```


### PR DESCRIPTION
## Summary

Add scaffolding for local manual testing with real Airzone Cloud credentials, keeping secrets safe from accidental commits and CI.

## Changes

### secrets/ (new directory)
- `secrets/.gitignore` — ignores everything except tracked templates
- `secrets/.env.example` — placeholder template (`AIRZONE_USERNAME`, `AIRZONE_PASSWORD`)
- `secrets/README.md` — usage and safety documentation

### .gitignore
- Added patterns: `secrets/.env`, `secrets/*.env`, `secrets/*.local`, `secrets/*.json`, `secrets/*.log`
- Added patterns: `.env`, `.env.*`, `!.env.example`

### .coderabbit.yaml
- Replaced blanket `!secrets/**` with targeted ignores for `secrets/*.env`, `secrets/*.local`, `secrets/*.json`, `secrets/*.log` — safe tracked templates remain reviewable
- Fixed Python 3.14 exception guidance: PEP 758 makes `except A, B:` (without `as`) valid; `except A, B as e:` remains invalid

## Validation
- `ruff check` — passed
- `black --check .` — passed
- `pytest -q` — all CI tests pass; no dependency on `secrets/.env` or real Airzone credentials

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a local environment template and documentation for manual testing, including clear guidance on what to commit vs keep local to avoid exposing credentials.

* **Chores**
  * Improved secret-file ignore rules to better target common secret-like extensions and environment variants, reducing the risk of accidentally committing sensitive data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->