### PR TITLE
[codex] Migrate HA custom component test stack

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,4 +32,4 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest -q
+          python -m pytest -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   and Home Assistant 2026.3.0+ minimum versions.
 - Dropped Python 3.13 from CI test matrix; tests now run on Python 3.14 only.
 - Bumped `homeassistant` minimum in `hacs.json` to `2026.3.0`.
+- Migrated test infrastructure to the Home Assistant custom component pytest stack.
 
 ### Added
 - Added `testpaths` and `asyncio_mode` config to `pyproject.toml`.

--- a/custom_components/airzoneclouddaikin/config_flow.py
+++ b/custom_components/airzoneclouddaikin/config_flow.py
@@ -207,7 +207,7 @@ class AirzoneConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Ask only for password; refresh the token; never persist password."""
         # Resolve entry
         entry = None
-        entry_id = (self.context or {}).get("entry_id")
+        entry_id = self.context.get("entry_id")
         if entry_id:
             entry = self.hass.config_entries.async_get_entry(entry_id)
         if entry is None:

--- a/custom_components/airzoneclouddaikin/config_flow.py
+++ b/custom_components/airzoneclouddaikin/config_flow.py
@@ -199,8 +199,6 @@ class AirzoneConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     # ------------------------- Reauth -------------------------
     async def async_step_reauth(self, entry_data: dict[str, Any]) -> FlowResult:
         """Start reauth for an existing entry."""
-        # HA usually provides entry_id in context; if not, we fallback below.
-        self._reauth_entry_id = (self.context or {}).get("entry_id")
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
@@ -209,8 +207,9 @@ class AirzoneConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Ask only for password; refresh the token; never persist password."""
         # Resolve entry
         entry = None
-        if getattr(self, "_reauth_entry_id", None):
-            entry = self.hass.config_entries.async_get_entry(self._reauth_entry_id)
+        entry_id = (self.context or {}).get("entry_id")
+        if entry_id:
+            entry = self.hass.config_entries.async_get_entry(entry_id)
         if entry is None:
             # Fallback: if a single entry exists, use it
             entries = self.hass.config_entries.async_entries(DOMAIN)

--- a/custom_components/airzoneclouddaikin/diagnostics.py
+++ b/custom_components/airzoneclouddaikin/diagnostics.py
@@ -14,7 +14,6 @@ Notes:
 from __future__ import annotations
 
 import re
-from copy import deepcopy
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
@@ -91,7 +90,7 @@ async def async_get_config_entry_diagnostics(
     entry_summary = {
         "title": entry.title,
         "data_keys": sorted(list(entry.data.keys())),  # keys only, never values
-        "options": deepcopy(entry.options),
+        "options": dict(entry.options or {}),
         "version": getattr(entry, "version", None),
     }
 

--- a/custom_components/airzoneclouddaikin/diagnostics.py
+++ b/custom_components/airzoneclouddaikin/diagnostics.py
@@ -90,7 +90,7 @@ async def async_get_config_entry_diagnostics(
     entry_summary = {
         "title": entry.title,
         "data_keys": sorted(list(entry.data.keys())),  # keys only, never values
-        "options": dict(entry.options or {}),
+        "options": dict(entry.options),
         "version": getattr(entry, "version", None),
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ combine-as-imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ combine-as-imports = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 
 # --- Optional hardening (uncomment if needed) ---
 # [tool.ruff]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,5 @@
 # Test dependencies for DKN Cloud for HASS
-pytest>=9,<10
-pytest-asyncio>=1.4,<1.5
-aiohttp>=3.10,<4
+pytest>=9
+pytest-homeassistant-custom-component>=0.13.339
+pytest-asyncio>=1.3
+aioresponses>=0.7.8

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,206 +1,231 @@
-"""Shared pytest fixtures for module stubbing."""
+"""Shared fixtures for DKN Cloud Home Assistant tests."""
 
 from __future__ import annotations
 
-import asyncio
-import importlib.util
-import sys
-import types
-from pathlib import Path
+from collections.abc import Callable
+from dataclasses import dataclass, field
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
+from aioresponses import CallbackResult
+from homeassistant.const import CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-ROOT = Path(__file__).resolve().parents[1]
+from custom_components.airzoneclouddaikin.config_flow import (
+    CONF_EXPOSE_PII,
+    CONF_SCAN_INTERVAL,
+)
+from custom_components.airzoneclouddaikin.const import (
+    CONF_ENABLE_HEAT_COOL,
+    CONF_SLEEP_TIMEOUT_ENABLED,
+    DOMAIN,
+)
 
 
-@pytest.fixture
-def stub_ha_and_integration_modules(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Stub Home Assistant and integration modules for isolated imports."""
-
-    def _set_module(name: str, module: types.ModuleType) -> None:
-        monkeypatch.setitem(sys.modules, name, module)
-
-    ha_module = types.ModuleType("homeassistant")
-    _set_module("homeassistant", ha_module)
-
-    core_module = types.ModuleType("homeassistant.core")
-
-    class HomeAssistant:  # pragma: no cover - type stub only
-        """Minimal HomeAssistant stub for type hints."""
-
-        def __init__(self) -> None:
-            self.data: dict[str, Any] = {}
-
-    core_module.HomeAssistant = HomeAssistant
-    _set_module("homeassistant.core", core_module)
-    ha_module.core = core_module
-
-    config_entries_module = types.ModuleType("homeassistant.config_entries")
-
-    class ConfigEntry:  # pragma: no cover - type stub only
-        """Minimal ConfigEntry stub."""
-
-        entry_id = "entry"
-
-    config_entries_module.ConfigEntry = ConfigEntry
-    _set_module("homeassistant.config_entries", config_entries_module)
-    ha_module.config_entries = config_entries_module
-
-    number_component = types.ModuleType("homeassistant.components.number")
-
-    class NumberEntity:  # pragma: no cover - base entity stub
-        def async_write_ha_state(self) -> None:
-            return None
-
-    class NumberMode:  # pragma: no cover - constant stub
-        """NumberMode stub."""
-
-        SLIDER = "slider"
-
-    number_component.NumberEntity = NumberEntity
-    number_component.NumberMode = NumberMode
-    _set_module("homeassistant.components.number", number_component)
-
-    helpers_entity_module = types.ModuleType("homeassistant.helpers.entity")
-
-    class EntityCategory:  # pragma: no cover - constant stub
-        """EntityCategory stub."""
-
-        CONFIG = "config"
-
-    helpers_entity_module.EntityCategory = EntityCategory
-    _set_module("homeassistant.helpers.entity", helpers_entity_module)
-
-    helpers_device_registry_module = types.ModuleType(
-        "homeassistant.helpers.device_registry"
-    )
-
-    class DeviceInfo(dict):  # pragma: no cover - minimal stub
-        """Dict-based DeviceInfo stub."""
-
-    helpers_device_registry_module.DeviceInfo = DeviceInfo
-    helpers_device_registry_module.CONNECTION_NETWORK_MAC = "mac"
-    _set_module("homeassistant.helpers.device_registry", helpers_device_registry_module)
-
-    helpers_update_module = types.ModuleType("homeassistant.helpers.update_coordinator")
-
-    class CoordinatorEntity:  # pragma: no cover - stub only
-        def __init__(self, coordinator: Any) -> None:
-            self.coordinator = coordinator
-
-        def __class_getitem__(cls, _item: Any) -> type:
-            return cls
-
-    helpers_update_module.CoordinatorEntity = CoordinatorEntity
-    _set_module("homeassistant.helpers.update_coordinator", helpers_update_module)
-
-    const_module = types.ModuleType("homeassistant.const")
-
-    class UnitOfTemperature:  # pragma: no cover - constant stub
-        """UnitOfTemperature stub."""
-
-        CELSIUS = "°C"
-
-    class UnitOfTime:  # pragma: no cover - constant stub
-        """UnitOfTime stub."""
-
-        MINUTES = "min"
-
-    const_module.UnitOfTemperature = UnitOfTemperature
-    const_module.UnitOfTime = UnitOfTime
-    _set_module("homeassistant.const", const_module)
-    ha_module.const = const_module
-
-    custom_components_module = types.ModuleType("custom_components")
-    custom_components_module.__path__ = [str(ROOT / "custom_components")]
-    _set_module("custom_components", custom_components_module)
-
-    airzone_package = types.ModuleType("custom_components.airzoneclouddaikin")
-    airzone_package.__path__ = [str(ROOT / "custom_components" / "airzoneclouddaikin")]
-    _set_module("custom_components.airzoneclouddaikin", airzone_package)
-
-    airzone_init_stub = types.ModuleType(
-        "custom_components.airzoneclouddaikin.__init__"
-    )
-
-    class _AirzoneCoordinatorStub:
-        """Lightweight AirzoneCoordinator replacement for number imports."""
-
-        def __init__(self) -> None:
-            self.data: dict[str, dict[str, Any]] = {}
-            self.hass: HomeAssistant | None = None
-
-    airzone_init_stub.AirzoneCoordinator = _AirzoneCoordinatorStub
-    _set_module("custom_components.airzoneclouddaikin.__init__", airzone_init_stub)
-
-    airzone_api_stub = types.ModuleType(
-        "custom_components.airzoneclouddaikin.airzone_api"
-    )
-
-    class AirzoneAPI:  # pragma: no cover - type stub
-        """Minimal AirzoneAPI stub."""
-
-    airzone_api_stub.AirzoneAPI = AirzoneAPI
-    _set_module("custom_components.airzoneclouddaikin.airzone_api", airzone_api_stub)
-
-    helpers_stub = types.ModuleType("custom_components.airzoneclouddaikin.helpers")
-
-    _locks: dict[tuple[str, str], asyncio.Lock] = {}
-
-    def acquire_device_lock(
-        _hass: Any,
-        entry_id: str,
-        device_id: str,
-        *_args: Any,
-        **_kwargs: Any,
-    ) -> asyncio.Lock:
-        key = (entry_id, device_id)
-        lock = _locks.get(key)
-        if lock is None:
-            lock = _locks.setdefault(key, asyncio.Lock())
-        return lock
-
-    def clamp_number(value: float, *_args: Any, **_kwargs: Any) -> float:
-        return value
-
-    def optimistic_get(
-        _hass: Any, _entry_id: str, _device_id: str, _field: str, backend_value: Any
-    ) -> Any:
-        return backend_value
-
-    def optimistic_set(*_args: Any, **_kwargs: Any) -> None:
-        return None
-
-    def optimistic_invalidate(*_args: Any, **_kwargs: Any) -> None:
-        return None
-
-    async def async_auto_exit_sleep_if_needed(*_args: Any, **_kwargs: Any) -> None:
-        return None
-
-    def schedule_post_write_refresh(*_args: Any, **_kwargs: Any) -> None:
-        return None
-
-    helpers_stub.acquire_device_lock = acquire_device_lock
-    helpers_stub.clamp_number = clamp_number
-    helpers_stub.optimistic_get = optimistic_get
-    helpers_stub.optimistic_set = optimistic_set
-    helpers_stub.optimistic_invalidate = optimistic_invalidate
-    helpers_stub.async_auto_exit_sleep_if_needed = async_auto_exit_sleep_if_needed
-    helpers_stub.schedule_post_write_refresh = schedule_post_write_refresh
-    _set_module("custom_components.airzoneclouddaikin.helpers", helpers_stub)
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(request: pytest.FixtureRequest) -> None:
+    """Enable loading custom integrations in every Home Assistant harness test."""
+    try:
+        request.getfixturevalue("enable_custom_integrations")
+    except pytest.FixtureLookupError:
+        return
 
 
 @pytest.fixture
-def load_number_module(stub_ha_and_integration_modules: None) -> types.ModuleType:
-    """Load the number module under test after stubbing dependencies."""
+def fake_email() -> str:
+    """Return a stable fake email address."""
+    return "user@example.com"
 
-    module_name = "custom_components.airzoneclouddaikin.number"
-    spec = importlib.util.spec_from_file_location(
-        module_name, ROOT / "custom_components" / "airzoneclouddaikin" / "number.py"
-    )
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = module
-    spec.loader.exec_module(module)
-    return module
+
+@pytest.fixture
+def fake_password() -> str:
+    """Return a stable fake password."""
+    return "not-a-real-password"
+
+
+@pytest.fixture
+def fake_token() -> str:
+    """Return a stable fake Airzone token."""
+    return "test-token"
+
+
+@pytest.fixture
+def dkn_config_entry_factory(
+    fake_email: str,
+    fake_token: str,
+) -> Callable[..., MockConfigEntry]:
+    """Return a factory for DKN MockConfigEntry instances."""
+
+    def _factory(
+        *,
+        entry_id: str = "dkn-entry",
+        email: str = fake_email,
+        token: str = fake_token,
+        title: str | None = None,
+        options: dict[str, Any] | None = None,
+        data: dict[str, Any] | None = None,
+        unique_id: str | None = None,
+        version: int = 2,
+    ) -> MockConfigEntry:
+        entry_options = {
+            "user_token": token,
+            CONF_SCAN_INTERVAL: 10,
+            CONF_EXPOSE_PII: False,
+            CONF_ENABLE_HEAT_COOL: False,
+            CONF_SLEEP_TIMEOUT_ENABLED: False,
+        }
+        if options:
+            entry_options.update(options)
+
+        entry_data = {CONF_USERNAME: email}
+        if data:
+            entry_data.update(data)
+
+        return MockConfigEntry(
+            domain=DOMAIN,
+            entry_id=entry_id,
+            title=title or email,
+            data=entry_data,
+            options=entry_options,
+            unique_id=unique_id if unique_id is not None else email.casefold(),
+            version=version,
+        )
+
+    return _factory
+
+
+@pytest.fixture
+def sample_device() -> dict[str, Any]:
+    """Return a representative Airzone device snapshot."""
+    return {
+        "id": "dev1",
+        "name": "Living Room",
+        "mac": "AA:BB:CC:DD:EE:FF",
+        "brand": "Airzone DKN",
+        "firmware": "1.0.0",
+        "modes": "11111",
+        "mode": "1",
+        "power": "1",
+        "scenary": "occupied",
+        "local_temp": "22.0",
+        "cold_consign": "24.0",
+        "heat_consign": "20.0",
+        "cold_speed": "2",
+        "heat_speed": "2",
+        "availables_speeds": "3",
+        "sleep_time": 30,
+        "min_temp_unoccupied": 16,
+        "max_temp_unoccupied": 28,
+        "connection_date": "2024-01-01T12:00:00+00:00",
+    }
+
+
+@pytest.fixture
+def sample_devices(sample_device: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Return a coordinator-style mapping of device id to device snapshot."""
+    return {str(sample_device["id"]): dict(sample_device)}
+
+
+class FakeAirzoneAPI:
+    """Small fake API object for setup/coordinator tests."""
+
+    def __init__(
+        self,
+        username: str | None = None,
+        session: Any | None = None,
+        *,
+        password: str | None = None,
+        token: str | None = None,
+        installations: list[dict[str, Any]] | None = None,
+        devices_by_installation: dict[str, list[dict[str, Any]]] | None = None,
+    ) -> None:
+        self.username = username
+        self.session = session
+        self.password = password
+        self.token = token
+        self.fetch_installations = AsyncMock(return_value=installations or [])
+        self.fetch_devices = AsyncMock(
+            side_effect=lambda installation_id: (devices_by_installation or {}).get(
+                str(installation_id), []
+            )
+        )
+        self.async_set_scenary = AsyncMock()
+        self.put_device_fields = AsyncMock()
+        self.send_event = AsyncMock()
+
+    async def login(self) -> bool:
+        """Pretend login succeeds when a token is available."""
+        return bool(self.token)
+
+    def clear_password(self) -> None:
+        """Drop the fake password."""
+        self.password = None
+
+
+@dataclass
+class DummyCoordinator:
+    """Minimal coordinator for direct entity unit tests."""
+
+    data: dict[str, dict[str, Any]]
+    hass: HomeAssistant
+    api: Any | None = None
+    refreshes: int = 0
+    listeners: list[Callable[..., None]] = field(default_factory=list)
+
+    def async_add_listener(
+        self,
+        listener: Callable[..., None],
+        _context: Any | None = None,
+    ) -> Callable[[], None]:
+        """Register a listener and return an unsubscribe callback."""
+        self.listeners.append(listener)
+
+        def _unsub() -> None:
+            if listener in self.listeners:
+                self.listeners.remove(listener)
+
+        return _unsub
+
+    async def async_request_refresh(self) -> None:
+        """Record refresh requests."""
+        self.refreshes += 1
+
+
+@pytest.fixture
+def dummy_coordinator_factory(
+    hass: HomeAssistant,
+) -> Callable[[dict[str, dict[str, Any]], Any | None], DummyCoordinator]:
+    """Return a factory for direct entity coordinator fakes."""
+
+    def _factory(
+        data: dict[str, dict[str, Any]],
+        api: Any | None = None,
+    ) -> DummyCoordinator:
+        return DummyCoordinator(data=data, hass=hass, api=api)
+
+    return _factory
+
+
+def capture_aioresponses_request(
+    captured: list[dict[str, Any]],
+    *,
+    status: int = 200,
+    payload: Any | None = None,
+) -> Callable[..., CallbackResult]:
+    """Return an aioresponses callback that records request kwargs."""
+
+    def _callback(url: Any, **kwargs: Any) -> CallbackResult:
+        captured.append(
+            {
+                "url": str(url),
+                "method": kwargs.get("method"),
+                "params": dict(kwargs.get("params") or {}),
+                "json": kwargs.get("json"),
+                "headers": dict(kwargs.get("headers") or {}),
+            }
+        )
+        return CallbackResult(status=status, payload=payload)
+
+    return _callback

--- a/tests/test_airzone_api.py
+++ b/tests/test_airzone_api.py
@@ -1,195 +1,28 @@
-"""HTTP client retry behavior tests without Home Assistant dependencies."""
+"""Tests for the Airzone HTTP client contract and retry behavior."""
 
 from __future__ import annotations
 
-import sys
-import types
-from pathlib import Path
+import re
+from typing import Any
 from unittest.mock import AsyncMock, patch
+from urllib.parse import parse_qsl
 
 import pytest
+from aiohttp import ClientResponseError, ClientSession
+from aiohttp.client_reqrep import RequestInfo
+from aioresponses import CallbackResult, aioresponses
+from homeassistant.exceptions import HomeAssistantError
+from multidict import CIMultiDict
+from yarl import URL
 
-try:
-    from aiohttp import ClientResponseError, ClientSession
-    from aiohttp.client_reqrep import RequestInfo
-    from multidict import CIMultiDict
-    from yarl import URL
-except ModuleNotFoundError:  # pragma: no cover - handled by CI deps
-    # NOTE: This module-level skip is expected in lightweight environments
-    # (e.g., Codex/Qodo) where aiohttp is not installed. CI installs aiohttp
-    # via requirements_test.txt so these tests run in automation.
-    pytest.skip("aiohttp is required for API retry tests", allow_module_level=True)
-
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
-# ---------------------------------------------------------------------------
-# Minimal Home Assistant shims so the package import works without HA
-# ---------------------------------------------------------------------------
-ha_module = types.ModuleType("homeassistant")
-sys.modules["homeassistant"] = ha_module
-
-components_module = types.ModuleType("homeassistant.components")
-persistent_notification_module = types.ModuleType(
-    "homeassistant.components.persistent_notification"
+from custom_components.airzoneclouddaikin.airzone_api import AirzoneAPI
+from custom_components.airzoneclouddaikin.const import (
+    API_DEVICES,
+    API_EVENTS,
+    API_INSTALLATION_RELATIONS,
+    API_LOGIN,
+    BASE_URL,
 )
-components_module.persistent_notification = persistent_notification_module
-sys.modules["homeassistant.components"] = components_module
-sys.modules["homeassistant.components.persistent_notification"] = (
-    persistent_notification_module
-)
-ha_module.components = components_module
-
-exceptions_module = types.ModuleType("homeassistant.exceptions")
-
-
-class HomeAssistantError(Exception):
-    """Minimal Home Assistant error placeholder."""
-
-    def __init__(self, *args: object, **kwargs: object) -> None:
-        super().__init__(*args)
-        self.translation_domain = kwargs.get("translation_domain")
-        self.translation_key = kwargs.get("translation_key")
-        self.translation_placeholders = kwargs.get("translation_placeholders") or {}
-
-
-exceptions_module.HomeAssistantError = HomeAssistantError
-ha_module.exceptions = exceptions_module
-sys.modules["homeassistant.exceptions"] = exceptions_module
-
-config_entries_module = types.ModuleType("homeassistant.config_entries")
-config_entries_module.SOURCE_REAUTH = "reauth"
-
-
-class ConfigEntry:  # pragma: no cover - used only for import wiring
-    def __init__(self, *args: object, **kwargs: object) -> None:
-        self.entry_id = "dummy"
-        self.data = {}
-        self.options = {}
-        self.unique_id = None
-        self.version = 1
-
-
-config_entries_module.ConfigEntry = ConfigEntry
-sys.modules["homeassistant.config_entries"] = config_entries_module
-ha_module.config_entries = config_entries_module
-
-const_module = types.ModuleType("homeassistant.const")
-const_module.CONF_USERNAME = "username"
-sys.modules["homeassistant.const"] = const_module
-ha_module.const = const_module
-
-core_module = types.ModuleType("homeassistant.core")
-
-
-class HomeAssistant:  # pragma: no cover - signature irrelevant for tests
-    pass
-
-
-core_module.HomeAssistant = HomeAssistant
-sys.modules["homeassistant.core"] = core_module
-ha_module.core = core_module
-
-
-class ConfigEntryAuthFailed(HomeAssistantError):
-    """Minimal auth failure placeholder."""
-
-
-exceptions_module.ConfigEntryAuthFailed = ConfigEntryAuthFailed
-
-helpers_module = types.ModuleType("homeassistant.helpers")
-aiohttp_client_module = types.ModuleType("homeassistant.helpers.aiohttp_client")
-sys.modules["homeassistant.helpers"] = helpers_module
-
-
-def async_get_clientsession(*_: object, **__: object) -> None:
-    return None
-
-
-aiohttp_client_module.async_get_clientsession = async_get_clientsession
-helpers_module.aiohttp_client = aiohttp_client_module
-sys.modules["homeassistant.helpers.aiohttp_client"] = aiohttp_client_module
-
-event_module = types.ModuleType("homeassistant.helpers.event")
-
-
-async def async_call_later(*_: object, **__: object) -> None:
-    return None
-
-
-event_module.async_call_later = async_call_later
-helpers_module.event = event_module
-sys.modules["homeassistant.helpers.event"] = event_module
-
-translation_module = types.ModuleType("homeassistant.helpers.translation")
-
-
-async def async_get_translations(*_: object, **__: object) -> dict[str, str]:
-    return {}
-
-
-translation_module.async_get_translations = async_get_translations
-helpers_module.translation = translation_module
-sys.modules["homeassistant.helpers.translation"] = translation_module
-
-update_coordinator_module = types.ModuleType("homeassistant.helpers.update_coordinator")
-
-
-class UpdateFailed(Exception):
-    """Placeholder for coordinator update failures."""
-
-
-class DataUpdateCoordinator:  # pragma: no cover - not exercised in tests
-    def __init__(
-        self,
-        hass: object,
-        *args: object,
-        update_method: object | None = None,
-        **kwargs: object,
-    ) -> None:
-        self.hass = hass
-        self.update_method = update_method
-        self.data = None
-        self._listeners: list[object] = []
-
-    async def async_config_entry_first_refresh(self) -> None:
-        if self.update_method:
-            self.data = await self.update_method()
-
-    def async_add_listener(self, listener: object) -> object:
-        self._listeners.append(listener)
-
-        def _unsub() -> None:
-            if listener in self._listeners:
-                self._listeners.remove(listener)
-
-        return _unsub
-
-    async def async_request_refresh(self) -> None:
-        return None
-
-    # Allow generics like DataUpdateCoordinator[dict[str, Any]] in annotations.
-    def __class_getitem__(cls, item: object) -> type:
-        return cls
-
-
-update_coordinator_module.UpdateFailed = UpdateFailed
-update_coordinator_module.DataUpdateCoordinator = DataUpdateCoordinator
-helpers_module.update_coordinator = update_coordinator_module
-sys.modules["homeassistant.helpers.update_coordinator"] = update_coordinator_module
-
-util_module = types.ModuleType("homeassistant.util")
-dt_module = types.ModuleType("homeassistant.util.dt")
-util_module.dt = dt_module
-helpers_module.util = util_module
-sys.modules["homeassistant.util"] = util_module
-sys.modules["homeassistant.util.dt"] = dt_module
-
-ha_module.helpers = helpers_module
-
-
-from custom_components.airzoneclouddaikin.airzone_api import AirzoneAPI  # noqa: E402
 
 
 def _client_response_error(
@@ -210,6 +43,14 @@ def _client_response_error(
         message="",
         headers=headers,
     )
+
+
+def _request_params(url: URL, kwargs: dict[str, Any]) -> dict[str, str]:
+    """Return query params from aioresponses callback inputs."""
+    params = dict(kwargs.get("params") or {})
+    if not params:
+        params = dict(parse_qsl(url.query_string))
+    return {str(key): str(value) for key, value in params.items()}
 
 
 def _make_api(
@@ -233,25 +74,41 @@ def _make_api(
 
 
 @pytest.mark.asyncio
-async def test_login_success_sets_token_and_preserves_password() -> None:
-    api = AirzoneAPI(
-        username="user@example.com",
-        password="secret",
-        session=AsyncMock(spec_set=ClientSession),
-    )
-    with patch.object(
-        api,
-        "_request",
-        AsyncMock(return_value={"user": {"authentication_token": "tok"}}),
-    ):
-        assert await api.login() is True
+async def test_login_posts_to_sign_in_and_sets_token() -> None:
+    """Login should POST credentials to /users/sign_in and store the token."""
+    captured: list[dict[str, Any]] = []
+
+    def _callback(url: URL, **kwargs: Any) -> CallbackResult:
+        captured.append({"url": str(url), "json": kwargs.get("json")})
+        return CallbackResult(
+            status=200,
+            payload={"user": {"authentication_token": "tok"}},
+        )
+
+    async with ClientSession() as session:
+        with aioresponses() as mocked:
+            mocked.post(f"{BASE_URL}{API_LOGIN}", callback=_callback)
+            api = AirzoneAPI(
+                username="user@example.com",
+                password="secret",
+                session=session,
+            )
+
+            assert await api.login() is True
 
     assert api.token == "tok"
     assert api.password == "secret"
+    assert captured == [
+        {
+            "url": f"{BASE_URL}{API_LOGIN}",
+            "json": {"email": "user@example.com", "password": "secret"},
+        }
+    ]
 
 
 @pytest.mark.asyncio
 async def test_login_handles_unauthorized() -> None:
+    """Unauthorized login should return False and leave the token empty."""
     api = AirzoneAPI(
         username="user@example.com",
         password="secret",
@@ -268,9 +125,151 @@ async def test_login_handles_unauthorized() -> None:
 
 
 @pytest.mark.asyncio
+async def test_fetch_installations_uses_installation_relations_endpoint() -> None:
+    """Installations should be read from /installation_relations with auth params."""
+    captured: list[dict[str, str]] = []
+
+    def _callback(url: URL, **kwargs: Any) -> CallbackResult:
+        captured.append(_request_params(url, kwargs))
+        return CallbackResult(
+            status=200,
+            payload={
+                "installation_relations": [
+                    {"installation_id": "install-123", "id": "relation-ignored"}
+                ]
+            },
+        )
+
+    async with ClientSession() as session:
+        with aioresponses() as mocked:
+            mocked.get(
+                re.compile(rf"^{re.escape(BASE_URL + API_INSTALLATION_RELATIONS)}.*$"),
+                callback=_callback,
+            )
+            api = AirzoneAPI("user@example.com", session, token="tok")
+
+            result = await api.fetch_installations()
+
+    assert result == [{"installation_id": "install-123", "id": "relation-ignored"}]
+    assert captured == [
+        {
+            "user_email": "user@example.com",
+            "user_token": "tok",
+            "format": "json",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fetch_devices_uses_installation_id_query_param() -> None:
+    """Device snapshots should be fetched from /devices with installation_id."""
+    captured: list[dict[str, str]] = []
+
+    def _callback(url: URL, **kwargs: Any) -> CallbackResult:
+        captured.append(_request_params(url, kwargs))
+        return CallbackResult(status=200, payload={"devices": [{"id": "dev1"}]})
+
+    async with ClientSession() as session:
+        with aioresponses() as mocked:
+            mocked.get(
+                re.compile(rf"^{re.escape(BASE_URL + API_DEVICES)}.*$"),
+                callback=_callback,
+            )
+            api = AirzoneAPI("user@example.com", session, token="tok")
+
+            result = await api.fetch_devices("install-123")
+
+    assert result == [{"id": "dev1"}]
+    assert captured == [
+        {
+            "user_email": "user@example.com",
+            "user_token": "tok",
+            "format": "json",
+            "installation_id": "install-123",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_put_device_fields_uses_device_endpoint_and_payload() -> None:
+    """Device writes should PUT the caller-provided payload to /devices/<id>."""
+    captured: list[dict[str, Any]] = []
+
+    def _callback(url: URL, **kwargs: Any) -> CallbackResult:
+        captured.append(
+            {
+                "url": str(url).partition("?")[0],
+                "params": _request_params(url, kwargs),
+                "json": kwargs.get("json"),
+            }
+        )
+        return CallbackResult(status=200, payload={"ok": True})
+
+    async with ClientSession() as session:
+        with aioresponses() as mocked:
+            mocked.put(
+                re.compile(rf"^{re.escape(BASE_URL + API_DEVICES + '/dev1')}.*$"),
+                callback=_callback,
+            )
+            api = AirzoneAPI("user@example.com", session, token="tok")
+
+            result = await api.put_device_fields(
+                "dev1", {"device": {"scenary": "sleep"}}
+            )
+
+    assert result == {"ok": True}
+    assert captured == [
+        {
+            "url": f"{BASE_URL}{API_DEVICES}/dev1",
+            "params": {
+                "user_email": "user@example.com",
+                "user_token": "tok",
+                "format": "json",
+            },
+            "json": {"device": {"scenary": "sleep"}},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_send_event_treats_any_2xx_as_success() -> None:
+    """The /events control endpoint should accept non-200 2xx responses."""
+    captured: list[dict[str, Any]] = []
+
+    def _callback(url: URL, **kwargs: Any) -> CallbackResult:
+        captured.append(
+            {
+                "params": _request_params(url, kwargs),
+                "json": kwargs.get("json"),
+            }
+        )
+        return CallbackResult(status=202, payload={"accepted": True})
+
+    payload = {"event": {"cgi": "modmaquina", "device_id": "dev1"}}
+    async with ClientSession() as session:
+        with aioresponses() as mocked:
+            mocked.post(
+                re.compile(rf"^{re.escape(BASE_URL + API_EVENTS)}.*$"),
+                callback=_callback,
+            )
+            api = AirzoneAPI("user@example.com", session, token="tok")
+
+            result = await api.send_event(payload)
+
+    assert result == {"accepted": True}
+    assert captured == [
+        {
+            "params": {"user_email": "user@example.com", "user_token": "tok"},
+            "json": payload,
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_authed_request_retries_429_with_retry_after(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """429 responses should honor Retry-After and then retry."""
     monkeypatch.setattr(
         "custom_components.airzoneclouddaikin.airzone_api.random.uniform",
         lambda *_: 0.0,
@@ -287,6 +286,7 @@ async def test_authed_request_retries_429_with_retry_after(
 
 @pytest.mark.asyncio
 async def test_authed_request_5xx_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """5xx responses should retry with exponential backoff then raise."""
     monkeypatch.setattr(
         "custom_components.airzoneclouddaikin.airzone_api.random.uniform",
         lambda *_: 0.0,
@@ -303,6 +303,7 @@ async def test_authed_request_5xx_backoff(monkeypatch: pytest.MonkeyPatch) -> No
 
 @pytest.mark.asyncio
 async def test_timeout_retries_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Timeouts should get one short retry."""
     monkeypatch.setattr(
         "custom_components.airzoneclouddaikin.airzone_api.random.uniform",
         lambda *_: 0.0,
@@ -319,6 +320,7 @@ async def test_timeout_retries_once(monkeypatch: pytest.MonkeyPatch) -> None:
 async def test_error_logs_do_not_leak_password(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    """Debug logs should not include credentials or full secret-bearing URLs."""
     api = AirzoneAPI(
         username="user@example.com",
         password="topsecret",
@@ -339,6 +341,7 @@ async def test_error_logs_do_not_leak_password(
 
 @pytest.mark.asyncio
 async def test_async_set_scenary_uses_wrapped_payload() -> None:
+    """Scenary writes should be nested under device."""
     api = AirzoneAPI(
         username="user@example.com",
         password="secret",
@@ -355,6 +358,7 @@ async def test_async_set_scenary_uses_wrapped_payload() -> None:
 
 @pytest.mark.asyncio
 async def test_send_event_maps_423_machine_not_ready() -> None:
+    """HTTP 423 from /events should map to the translated HA error."""
     api = AirzoneAPI(
         username="user@example.com",
         password="secret",

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,351 +1,53 @@
-"""Tests for Airzone climate HEAT_COOL exposure gating."""
+"""Tests for Airzone climate entity behavior."""
 
 from __future__ import annotations
 
-import importlib.util
-import sys
-import types
-from dataclasses import dataclass
-from enum import IntFlag, StrEnum
-from pathlib import Path
+from collections.abc import Callable
 from typing import Any
 
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
-ha_module = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
-components_module = sys.modules.setdefault(
-    "homeassistant.components", types.ModuleType("homeassistant.components")
-)
-ha_module.components = getattr(ha_module, "components", components_module)
-
-climate_module = sys.modules.setdefault(
-    "homeassistant.components.climate",
-    types.ModuleType("homeassistant.components.climate"),
-)
-
-climate_const_module = sys.modules.setdefault(
-    "homeassistant.components.climate.const",
-    types.ModuleType("homeassistant.components.climate.const"),
-)
-
-const_module = sys.modules.setdefault(
-    "homeassistant.const", types.ModuleType("homeassistant.const")
-)
-
-core_module = sys.modules.setdefault(
-    "homeassistant.core", types.ModuleType("homeassistant.core")
-)
-
-exceptions_module = sys.modules.setdefault(
-    "homeassistant.exceptions", types.ModuleType("homeassistant.exceptions")
-)
-config_entries_module = sys.modules.setdefault(
-    "homeassistant.config_entries", types.ModuleType("homeassistant.config_entries")
-)
-aiohttp_client_module = sys.modules.setdefault(
-    "homeassistant.helpers.aiohttp_client",
-    types.ModuleType("homeassistant.helpers.aiohttp_client"),
-)
-dt_module = sys.modules.setdefault(
-    "homeassistant.util.dt", types.ModuleType("homeassistant.util.dt")
-)
-
-helpers_module = sys.modules.setdefault(
-    "homeassistant.helpers", types.ModuleType("homeassistant.helpers")
-)
-
-helpers_event_module = sys.modules.setdefault(
-    "homeassistant.helpers.event", types.ModuleType("homeassistant.helpers.event")
-)
-helpers_translation_module = sys.modules.setdefault(
-    "homeassistant.helpers.translation",
-    types.ModuleType("homeassistant.helpers.translation"),
-)
-device_registry_module = sys.modules.setdefault(
-    "homeassistant.helpers.device_registry",
-    types.ModuleType("homeassistant.helpers.device_registry"),
-)
-
-helpers_update_module = sys.modules.setdefault(
-    "homeassistant.helpers.update_coordinator",
-    types.ModuleType("homeassistant.helpers.update_coordinator"),
-)
-
-if not hasattr(helpers_event_module, "async_call_later"):
-
-    def async_call_later(*_args: Any, **_kwargs: Any) -> None:
-        raise NotImplementedError
-
-    helpers_event_module.async_call_later = async_call_later
-
-if not hasattr(helpers_translation_module, "async_get_translations"):
-
-    async def async_get_translations(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
-        return {}
-
-    helpers_translation_module.async_get_translations = async_get_translations
-
-helpers_module.event = helpers_event_module
-helpers_module.translation = helpers_translation_module
-
-aiohttp_module = sys.modules.setdefault("aiohttp", types.ModuleType("aiohttp"))
-
-if not hasattr(aiohttp_module, "ClientResponseError"):
-
-    class _ClientResponseError(Exception):
-        pass
-
-    aiohttp_module.ClientResponseError = _ClientResponseError
-
-
-if not hasattr(core_module, "callback"):
-
-    def callback(func):
-        return func
-
-    core_module.callback = callback
-
-if not hasattr(exceptions_module, "ConfigEntryAuthFailed"):
-
-    class ConfigEntryAuthFailed(Exception):
-        pass
-
-    exceptions_module.ConfigEntryAuthFailed = ConfigEntryAuthFailed
-
-if not hasattr(config_entries_module, "SOURCE_REAUTH"):
-    config_entries_module.SOURCE_REAUTH = "reauth"
-
-if not hasattr(config_entries_module, "ConfigEntry"):
-
-    class ConfigEntry:
-        def __init__(self) -> None:
-            self.entry_id = "entry"
-            self.data: dict[str, Any] = {}
-            self.options: dict[str, Any] = {}
-            self.version = 1
-            self.unique_id: str | None = None
-
-    config_entries_module.ConfigEntry = ConfigEntry
-
-if not hasattr(aiohttp_client_module, "async_get_clientsession"):
-
-    async def async_get_clientsession(*_args: Any, **_kwargs: Any) -> object:
-        return object()
-
-    aiohttp_client_module.async_get_clientsession = async_get_clientsession
-
-helpers_module.aiohttp_client = aiohttp_client_module
-
-if not hasattr(dt_module, "utcnow"):
-
-    from datetime import datetime
-
-    def utcnow() -> datetime:
-        return datetime.utcnow()
-
-    dt_module.utcnow = utcnow
-
-if not hasattr(core_module, "HomeAssistant"):
-
-    class HomeAssistant:
-        loop: Any
-        data: dict[str, Any]
-
-    core_module.HomeAssistant = HomeAssistant
-
-
-if not hasattr(const_module, "ATTR_TEMPERATURE"):
-    const_module.ATTR_TEMPERATURE = "temperature"
-
-if not hasattr(const_module, "PRECISION_WHOLE"):
-    const_module.PRECISION_WHOLE = 1
-
-if not hasattr(const_module, "CONF_USERNAME"):
-    const_module.CONF_USERNAME = "username"
-
-if not hasattr(const_module, "UnitOfTemperature"):
-
-    class UnitOfTemperature(StrEnum):
-        CELSIUS = "°C"
-
-    const_module.UnitOfTemperature = UnitOfTemperature
-
-
-if not hasattr(climate_const_module, "HVACMode"):
-
-    class HVACMode(StrEnum):
-        OFF = "off"
-        COOL = "cool"
-        HEAT = "heat"
-        FAN_ONLY = "fan_only"
-        DRY = "dry"
-        HEAT_COOL = "heat_cool"
-
-    climate_const_module.HVACMode = HVACMode
-
-if not hasattr(climate_const_module, "ClimateEntityFeature"):
-
-    class ClimateEntityFeature(IntFlag):
-        TARGET_TEMPERATURE = 1
-        FAN_MODE = 2
-        PRESET_MODE = 4
-        TURN_ON = 8
-        TURN_OFF = 16
-
-    climate_const_module.ClimateEntityFeature = ClimateEntityFeature
-
-if not hasattr(climate_module, "ClimateEntity"):
-
-    class ClimateEntity:  # pragma: no cover - stub only
-        """Minimal ClimateEntity stub."""
-
-        _attr_hvac_mode: HVACMode | None = None
-
-        def __init__(self) -> None:
-            self.hass: Any = None
-
-    climate_module.ClimateEntity = ClimateEntity
-
-if not hasattr(climate_module, "HVACMode"):
-    climate_module.HVACMode = climate_const_module.HVACMode
-
-if not hasattr(climate_module, "ClimateEntityFeature"):
-    climate_module.ClimateEntityFeature = climate_const_module.ClimateEntityFeature
-
-
-if not hasattr(device_registry_module, "CONNECTION_NETWORK_MAC"):
-    device_registry_module.CONNECTION_NETWORK_MAC = "network_mac"
-
-if not hasattr(device_registry_module, "DeviceInfo"):
-
-    @dataclass
-    class DeviceInfo:  # pragma: no cover - stub only
-        identifiers: set[tuple[str, str]]
-        manufacturer: str | None = None
-        model: str | None = None
-        sw_version: str | None = None
-        name: str | None = None
-        connections: set[tuple[str, str]] | None = None
-
-    device_registry_module.DeviceInfo = DeviceInfo
-
-helpers_module.device_registry = device_registry_module
-sys.modules.setdefault("homeassistant.helpers.device_registry", device_registry_module)
-
-if not hasattr(helpers_update_module, "DataUpdateCoordinator"):
-
-    class DataUpdateCoordinator:  # pragma: no cover - stub only
-        ...
-
-    helpers_update_module.DataUpdateCoordinator = DataUpdateCoordinator
-
-if not hasattr(helpers_update_module, "CoordinatorEntity"):
-
-    class CoordinatorEntity:  # pragma: no cover - stub only
-        """Coordinator entity stub that captures the coordinator reference."""
-
-        def __init__(self, coordinator: Any) -> None:
-            self.coordinator = coordinator
-            self.hass = getattr(coordinator, "hass", None)
-
-        def __class_getitem__(cls, _item: Any) -> type[CoordinatorEntity]:
-            return cls
-
-    helpers_update_module.CoordinatorEntity = CoordinatorEntity
-
-helpers_module.update_coordinator = helpers_update_module
-sys.modules.setdefault(
-    "homeassistant.helpers.update_coordinator", helpers_update_module
-)
-
-custom_components_module = sys.modules.setdefault(
-    "custom_components", types.ModuleType("custom_components")
-)
-custom_components_module.__path__ = [str(ROOT / "custom_components")]
-
-airzone_package = sys.modules.setdefault(
-    "custom_components.airzoneclouddaikin",
-    types.ModuleType("custom_components.airzoneclouddaikin"),
-)
-airzone_package.__path__ = [str(ROOT / "custom_components" / "airzoneclouddaikin")]
-
-airzone_init_module = sys.modules.setdefault(
-    "custom_components.airzoneclouddaikin.__init__",
-    types.ModuleType("custom_components.airzoneclouddaikin.__init__"),
-)
-
-if not hasattr(airzone_init_module, "AirzoneCoordinator"):
-
-    class AirzoneCoordinator:  # pragma: no cover - stub only
-        data: dict[str, dict[str, Any]] | None = None
-
-    airzone_init_module.AirzoneCoordinator = AirzoneCoordinator
-
-climate_spec = importlib.util.spec_from_file_location(
-    "custom_components.airzoneclouddaikin.climate",
-    ROOT / "custom_components" / "airzoneclouddaikin" / "climate.py",
-)
-assert climate_spec and climate_spec.loader
-climate_module_impl = importlib.util.module_from_spec(climate_spec)
-sys.modules[climate_spec.name] = climate_module_impl
-climate_spec.loader.exec_module(climate_module_impl)
-
-AirzoneClimate = climate_module_impl.AirzoneClimate
-HVACMode = climate_const_module.HVACMode
-ClimateEntityFeature = climate_const_module.ClimateEntityFeature
-DOMAIN = climate_module_impl.DOMAIN
-
-
-class DummyConfigEntries:
-    def async_get_entry(self, _entry_id: str) -> None:
-        return None
-
-
-class DummyHass:
-    def __init__(self) -> None:
-        self.data: dict[str, dict[str, dict[str, Any]]] = {}
-        self.config_entries = DummyConfigEntries()
-
-
-class DummyCoordinator:
-    def __init__(self, data: dict[str, dict[str, Any]]) -> None:
-        self.data = data
-        self.hass: DummyHass | None = None
+from homeassistant.components.climate.const import ClimateEntityFeature, HVACMode
+from homeassistant.core import HomeAssistant
+
+from custom_components.airzoneclouddaikin.climate import AirzoneClimate
+from custom_components.airzoneclouddaikin.const import DOMAIN
 
 
 def _make_climate(
-    device_snapshot: dict[str, Any], *, heat_cool_opt_in: bool
+    hass: HomeAssistant,
+    dummy_coordinator_factory: Callable[[dict[str, dict[str, Any]], Any | None], Any],
+    device_snapshot: dict[str, Any],
+    *,
+    heat_cool_opt_in: bool,
 ) -> AirzoneClimate:
+    """Instantiate an AirzoneClimate with a lightweight coordinator."""
     entry_id = "entry"
     device_id = "device"
-    hass = DummyHass()
     hass.data.setdefault(DOMAIN, {}).setdefault(entry_id, {})[
         "heat_cool_opt_in"
     ] = heat_cool_opt_in
 
-    coordinator = DummyCoordinator({device_id: device_snapshot})
-    coordinator.hass = hass
-
+    coordinator = dummy_coordinator_factory({device_id: device_snapshot})
     entity = AirzoneClimate(coordinator, entry_id, device_id)
     entity.hass = hass
     return entity
 
 
-def test_heat_cool_hidden_without_device_support() -> None:
+def test_heat_cool_hidden_without_device_support(
+    hass: HomeAssistant,
+    dummy_coordinator_factory: Callable[[dict[str, dict[str, Any]], Any | None], Any],
+) -> None:
     """HEAT_COOL must remain hidden when the device bitmask lacks P2=4."""
-
     device = {
-        "name": "Zone",  # name only for completeness
-        "modes": "11101",  # P2=1,2,3,5 enabled; P2=4 disabled
+        "name": "Zone",
+        "modes": "11101",
         "mode": "1",
         "power": "1",
     }
-    entity = _make_climate(device, heat_cool_opt_in=True)
+    entity = _make_climate(
+        hass, dummy_coordinator_factory, device, heat_cool_opt_in=True
+    )
 
-    modes = entity.hvac_modes
-    assert modes == [
+    assert entity.hvac_modes == [
         HVACMode.OFF,
         HVACMode.COOL,
         HVACMode.HEAT,
@@ -354,19 +56,22 @@ def test_heat_cool_hidden_without_device_support() -> None:
     ]
 
 
-def test_heat_cool_exposed_when_device_supports_and_opt_in_enabled() -> None:
+def test_heat_cool_exposed_when_device_supports_and_opt_in_enabled(
+    hass: HomeAssistant,
+    dummy_coordinator_factory: Callable[[dict[str, dict[str, Any]], Any | None], Any],
+) -> None:
     """HEAT_COOL should be exposed when both support and opt-in are true."""
-
     device = {
         "name": "Zone",
-        "modes": "11111",  # Includes P2=4
+        "modes": "11111",
         "mode": "1",
         "power": "1",
     }
-    entity = _make_climate(device, heat_cool_opt_in=True)
+    entity = _make_climate(
+        hass, dummy_coordinator_factory, device, heat_cool_opt_in=True
+    )
 
-    modes = entity.hvac_modes
-    assert modes == [
+    assert entity.hvac_modes == [
         HVACMode.OFF,
         HVACMode.COOL,
         HVACMode.HEAT,
@@ -376,19 +81,22 @@ def test_heat_cool_exposed_when_device_supports_and_opt_in_enabled() -> None:
     ]
 
 
-def test_heat_cool_retained_when_current_mode_loses_support() -> None:
-    """The current HEAT_COOL mode should remain visible even if support disappears."""
-
+def test_heat_cool_retained_when_current_mode_loses_support(
+    hass: HomeAssistant,
+    dummy_coordinator_factory: Callable[[dict[str, dict[str, Any]], Any | None], Any],
+) -> None:
+    """The current HEAT_COOL mode should remain visible after support disappears."""
     device = {
         "name": "Zone",
-        "modes": "11101",  # P2=4 disabled post-refresh
+        "modes": "11101",
         "mode": "4",
         "power": "1",
     }
-    entity = _make_climate(device, heat_cool_opt_in=True)
+    entity = _make_climate(
+        hass, dummy_coordinator_factory, device, heat_cool_opt_in=True
+    )
 
-    modes = entity.hvac_modes
-    assert modes == [
+    assert entity.hvac_modes == [
         HVACMode.OFF,
         HVACMode.COOL,
         HVACMode.HEAT,
@@ -398,9 +106,11 @@ def test_heat_cool_retained_when_current_mode_loses_support() -> None:
     ]
 
 
-def test_supported_features_matrix_by_hvac_mode() -> None:
+def test_supported_features_matrix_by_hvac_mode(
+    hass: HomeAssistant,
+    dummy_coordinator_factory: Callable[[dict[str, dict[str, Any]], Any | None], Any],
+) -> None:
     """Freeze supported_features matrix by HVAC mode, including alias mode 8."""
-
     base = (
         ClimateEntityFeature.PRESET_MODE
         | ClimateEntityFeature.TURN_ON
@@ -438,5 +148,7 @@ def test_supported_features_matrix_by_hvac_mode() -> None:
             "modes": "11111",
             **snapshot,
         }
-        entity = _make_climate(device, heat_cool_opt_in=True)
+        entity = _make_climate(
+            hass, dummy_coordinator_factory, device, heat_cool_opt_in=True
+        )
         assert entity.supported_features == expected

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,538 +1,282 @@
-"""Config and options flow tests using lightweight Home Assistant stubs."""
+"""Config and options flow tests using the Home Assistant test harness."""
 
 from __future__ import annotations
 
-import asyncio
-import sys
-import types
-from pathlib import Path
+from collections.abc import Callable
 from typing import Any
-from unittest.mock import AsyncMock
 
 import pytest
-
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
-
-class FlowResultType:
-    """Minimal FlowResultType replacement used by the stubs."""
-
-    FORM = "form"
-    CREATE_ENTRY = "create_entry"
-    ABORT = "abort"
-
-
-class AbortFlow(Exception):
-    """Raised when a duplicate unique ID is configured."""
-
-
-class ConfigEntry:
-    """Simple ConfigEntry stand-in for tests."""
-
-    _id = 0
-
-    def __init__(
-        self,
-        *,
-        domain: str,
-        data: dict[str, Any] | None = None,
-        options: dict[str, Any] | None = None,
-        unique_id: str | None = None,
-    ) -> None:
-        ConfigEntry._id += 1
-        self.entry_id = f"entry_{ConfigEntry._id}"
-        self.domain = domain
-        self.data = data or {}
-        self.options = options or {}
-        self.unique_id = unique_id
-
-    def add_to_hass(self, hass: HassStub) -> None:
-        hass.config_entries._entries.append(self)
-
-
-class ConfigEntries:
-    """Collection helper for ConfigEntry stubs."""
-
-    def __init__(self) -> None:
-        self._entries: list[ConfigEntry] = []
-
-    def async_get_entry(self, entry_id: str) -> ConfigEntry | None:
-        for entry in self._entries:
-            if entry.entry_id == entry_id:
-                return entry
-        return None
-
-    def async_entries(self, domain: str | None = None) -> list[ConfigEntry]:
-        if domain is None:
-            return list(self._entries)
-        return [entry for entry in self._entries if entry.domain == domain]
-
-    def async_update_entry(
-        self, entry: ConfigEntry, *, options: dict[str, Any]
-    ) -> None:
-        entry.options = options
-
-    def _unique_id_exists(self, unique_id: str | None) -> bool:
-        if unique_id is None:
-            return False
-        return any(entry.unique_id == unique_id for entry in self._entries)
-
-
-class ConfigFlow:
-    """Minimal ConfigFlow base to satisfy the integration flow."""
-
-    def __init_subclass__(cls, **kwargs: Any) -> None:
-        """Allow Home Assistant-style subclass kwargs like domain."""
-        super().__init_subclass__()
-
-    def __init__(self) -> None:
-        self.hass: HassStub | None = None
-        self.context: dict[str, Any] = {}
-        self._unique_id: str | None = None
-
-    async def async_set_unique_id(self, unique_id: str) -> None:
-        self._unique_id = unique_id
-
-    def _abort_if_unique_id_configured(self) -> None:
-        if self.hass and self.hass.config_entries._unique_id_exists(self._unique_id):
-            raise AbortFlow()
-
-    def async_show_form(
-        self, *, step_id: str, data_schema: Any, errors: dict[str, str] | None = None
-    ) -> dict[str, Any]:
-        return {
-            "type": FlowResultType.FORM,
-            "step_id": step_id,
-            "data_schema": data_schema,
-            "errors": errors or {},
-        }
-
-    def async_abort(self, *, reason: str) -> dict[str, Any]:
-        return {"type": FlowResultType.ABORT, "reason": reason}
-
-    def async_create_entry(
-        self, *, title: str, data: dict[str, Any], options: dict[str, Any] | None = None
-    ) -> dict[str, Any]:
-        return {
-            "type": FlowResultType.CREATE_ENTRY,
-            "title": title,
-            "data": data,
-            "options": options or {},
-        }
-
-
-class OptionsFlow:
-    """Minimal OptionsFlow base."""
-
-    def __init__(self, config_entry: ConfigEntry) -> None:
-        self.config_entry = config_entry
-        self.hass: HassStub | None = None
-
-    def async_show_form(
-        self, *, step_id: str, data_schema: Any, errors: dict[str, str] | None = None
-    ) -> dict[str, Any]:
-        return {
-            "type": FlowResultType.FORM,
-            "step_id": step_id,
-            "data_schema": data_schema,
-            "errors": errors or {},
-        }
-
-    def async_create_entry(
-        self, *, title: str = "", data: dict[str, Any] | None = None
-    ) -> dict[str, Any]:
-        return {"type": FlowResultType.CREATE_ENTRY, "title": title, "data": data or {}}
-
-
-class HassStub:
-    """Lightweight Home Assistant stub with config entry tracking."""
-
-    def __init__(self) -> None:
-        self.config_entries = ConfigEntries()
-        self.data: dict[str, Any] = {}
-
-
-def _install_voluptuous_stub() -> None:
-    """Provide a tiny voluptuous stub to avoid external dependency."""
-
-    vol_module = types.ModuleType("voluptuous")
-
-    class Schema:  # pragma: no cover - structure only
-        def __init__(self, data: Any) -> None:
-            self.data = data
-
-    class Marker:  # pragma: no cover - structure only
-        def __init__(self, key: Any, default: Any | None = None) -> None:
-            self.key = key
-            self.default = default
-
-    class Required(Marker):
-        pass
-
-    class Optional(Marker):
-        pass
-
-    class Range:  # pragma: no cover - structure only
-        def __init__(self, min: int | None = None, max: int | None = None) -> None:
-            self.min = min
-            self.max = max
-
-    def All(*validators: Any) -> tuple[Any, ...]:  # noqa: N802 - match voluptuous API
-        return validators
-
-    def Coerce(target_type: type) -> Any:  # noqa: N802 - match voluptuous API
-        return target_type
-
-    vol_module.Schema = Schema
-    vol_module.Required = Required
-    vol_module.Optional = Optional
-    vol_module.Range = Range
-    vol_module.All = All
-    vol_module.Coerce = Coerce
-
-    sys.modules["voluptuous"] = vol_module
-
-
-def _install_homeassistant_stubs() -> None:
-    """Install minimal Home Assistant modules for importing config_flow."""
-
-    ha_module = sys.modules.setdefault(
-        "homeassistant", types.ModuleType("homeassistant")
-    )
-
-    config_entries_module = types.ModuleType("homeassistant.config_entries")
-    config_entries_module.ConfigFlow = ConfigFlow
-    config_entries_module.OptionsFlow = OptionsFlow
-    config_entries_module.ConfigEntry = ConfigEntry
-    config_entries_module.SOURCE_USER = "user"
-    config_entries_module.SOURCE_REAUTH = "reauth"
-    sys.modules["homeassistant.config_entries"] = config_entries_module
-
-    const_module = types.ModuleType("homeassistant.const")
-    const_module.CONF_USERNAME = "username"
-    const_module.CONF_PASSWORD = "password"
-    sys.modules["homeassistant.const"] = const_module
-
-    core_module = types.ModuleType("homeassistant.core")
-
-    class HomeAssistant:  # pragma: no cover - stub only
-        pass
-
-    core_module.HomeAssistant = HomeAssistant
-    sys.modules["homeassistant.core"] = core_module
-
-    data_entry_flow_module = types.ModuleType("homeassistant.data_entry_flow")
-    data_entry_flow_module.FlowResultType = FlowResultType
-    data_entry_flow_module.FlowResult = dict
-    sys.modules["homeassistant.data_entry_flow"] = data_entry_flow_module
-
-    helpers_module = sys.modules.setdefault(
-        "homeassistant.helpers", types.ModuleType("homeassistant.helpers")
-    )
-
-    aiohttp_client_module = types.ModuleType("homeassistant.helpers.aiohttp_client")
-
-    def async_get_clientsession(_hass: HassStub) -> object:
-        return object()
-
-    aiohttp_client_module.async_get_clientsession = async_get_clientsession
-    sys.modules["homeassistant.helpers.aiohttp_client"] = aiohttp_client_module
-
-    cv_module = types.ModuleType("homeassistant.helpers.config_validation")
-
-    def boolean(value: Any) -> bool:
-        return bool(value)
-
-    def string(value: Any) -> str:
-        return str(value)
-
-    cv_module.boolean = boolean
-    cv_module.string = string
-    helpers_module.config_validation = cv_module
-    sys.modules["homeassistant.helpers.config_validation"] = cv_module
-
-    event_module = types.ModuleType("homeassistant.helpers.event")
-
-    def async_call_later(*_args: Any, **_kwargs: Any) -> None:
-        return None
-
-    event_module.async_call_later = async_call_later
-    helpers_module.event = event_module
-    sys.modules["homeassistant.helpers.event"] = event_module
-
-    update_coordinator_module = types.ModuleType(
-        "homeassistant.helpers.update_coordinator"
-    )
-
-    class DataUpdateCoordinator:  # pragma: no cover - stub only
-        pass
-
-    update_coordinator_module.DataUpdateCoordinator = DataUpdateCoordinator
-    helpers_module.update_coordinator = update_coordinator_module
-    sys.modules["homeassistant.helpers.update_coordinator"] = update_coordinator_module
-
-    ha_module.config_entries = config_entries_module
-    ha_module.const = const_module
-    ha_module.core = core_module
-    ha_module.data_entry_flow = data_entry_flow_module
-    ha_module.helpers = helpers_module
-
-
-_install_voluptuous_stub()
-_install_homeassistant_stubs()
-
-custom_components_module = sys.modules.setdefault(
-    "custom_components", types.ModuleType("custom_components")
-)
-custom_components_module.__path__ = [str(ROOT / "custom_components")]
-
-airzone_package = sys.modules.setdefault(
-    "custom_components.airzoneclouddaikin",
-    types.ModuleType("custom_components.airzoneclouddaikin"),
-)
-airzone_package.__path__ = [str(ROOT / "custom_components" / "airzoneclouddaikin")]
-
-from homeassistant.config_entries import SOURCE_REAUTH  # type: ignore  # noqa: E402
-from homeassistant.const import (  # type: ignore  # noqa: E402
-    CONF_PASSWORD,
-    CONF_USERNAME,
-)
-from homeassistant.data_entry_flow import (  # type: ignore  # noqa: E402
-    FlowResultType as HAFlowResultType,
-)
-
-from custom_components.airzoneclouddaikin.config_flow import (  # noqa: E402
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.airzoneclouddaikin import airzone_api
+from custom_components.airzoneclouddaikin.config_flow import (
     CONF_EXPOSE_PII,
     CONF_SCAN_INTERVAL,
-    AirzoneConfigFlow,
     AirzoneOptionsFlow,
 )
-from custom_components.airzoneclouddaikin.const import (  # noqa: E402
+from custom_components.airzoneclouddaikin.const import (
     CONF_ENABLE_HEAT_COOL,
     CONF_SLEEP_TIMEOUT_ENABLED,
     DOMAIN,
 )
 
 
-def _run(coro: Any) -> Any:
-    loop = asyncio.new_event_loop()
-    try:
-        return loop.run_until_complete(coro)
-    finally:
-        loop.close()
+class LoginAirzoneAPI:
+    """Fake Airzone API used by config flow tests."""
+
+    instances: list[LoginAirzoneAPI] = []
+    login_result: bool | str | Exception = True
+    token_value: str = "login-token"
+
+    def __init__(
+        self,
+        username: str,
+        session: Any,
+        *,
+        password: str | None = None,
+        token: str | None = None,
+    ) -> None:
+        self.username = username
+        self.session = session
+        self.password = password
+        self.token = token
+        self.cleared_password = False
+        self.instances.append(self)
+
+    async def login(self) -> bool | str:
+        """Return the configured fake login result."""
+        result = self.login_result
+        if isinstance(result, Exception):
+            raise result
+        if isinstance(result, str):
+            self.token = result
+            return result
+        if result is True:
+            self.token = self.token_value
+            return True
+        self.token = ""
+        return False
+
+    def clear_password(self) -> None:
+        """Mark password cleanup."""
+        self.cleared_password = True
+        self.password = None
 
 
 @pytest.fixture
-def hass() -> HassStub:
-    """Provide a fresh Hass stub for each test."""
-
-    return HassStub()
-
-
-@pytest.fixture
-def api_mock() -> AsyncMock:
-    """Fixture that installs a stub AirzoneAPI returning a shared mock."""
-
-    api_mock = AsyncMock()
-    api_mock.login = AsyncMock(return_value="login-token")
-    api_mock.token = "login-token"
-    api_mock.clear_password = lambda: None
-
-    module_path = "custom_components.airzoneclouddaikin.airzone_api"
-    api_module = types.ModuleType(module_path)
-    api_module.AirzoneAPI = lambda *args, **kwargs: api_mock
-    sys.modules[module_path] = api_module
-
-    parent = sys.modules.get("custom_components.airzoneclouddaikin")
-    if parent is not None:
-        parent.airzone_api = api_module
-
-    return api_mock
+def login_api_class(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_token: str,
+) -> type[LoginAirzoneAPI]:
+    """Patch the config flow API dependency with a fake login API."""
+    LoginAirzoneAPI.instances = []
+    LoginAirzoneAPI.login_result = True
+    LoginAirzoneAPI.token_value = fake_token
+    monkeypatch.setattr(airzone_api, "AirzoneAPI", LoginAirzoneAPI)
+    return LoginAirzoneAPI
 
 
-def test_user_step_shows_initial_form(hass: HassStub) -> None:
-    flow = AirzoneConfigFlow()
-    flow.hass = hass
+async def test_user_step_shows_initial_form(hass: HomeAssistant) -> None:
+    """The user step should show its initial form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
 
-    result = _run(flow.async_step_user(user_input=None))
-
-    assert result["type"] is HAFlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert "data_schema" in result
 
 
-def test_user_step_success_creates_entry(hass: HassStub, api_mock: AsyncMock) -> None:
-    flow = AirzoneConfigFlow()
-    flow.hass = hass
-
+async def test_user_step_success_creates_entry(
+    hass: HomeAssistant,
+    login_api_class: type[LoginAirzoneAPI],
+    fake_token: str,
+    fake_password: str,
+) -> None:
+    """Successful login should create an entry with token stored in options."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
     user_input = {
         CONF_USERNAME: "User@Example.Com ",
-        CONF_PASSWORD: "secret",
+        CONF_PASSWORD: fake_password,
         CONF_SCAN_INTERVAL: 15,
         CONF_EXPOSE_PII: True,
+        CONF_SLEEP_TIMEOUT_ENABLED: True,
     }
 
-    result = _run(flow.async_step_user(user_input=user_input))
-
-    assert result["type"] is HAFlowResultType.CREATE_ENTRY
-    normalized_email = user_input[CONF_USERNAME].strip()
-    assert result["title"] == normalized_email
-    assert result["data"] == {CONF_USERNAME: normalized_email}
-
-    options = result["options"]
-    assert options["user_token"] == "login-token"
-    assert options[CONF_SCAN_INTERVAL] == 15
-    assert options[CONF_EXPOSE_PII] is True
-    assert CONF_ENABLE_HEAT_COOL not in options
-
-
-def test_user_step_invalid_auth_from_api(hass: HassStub, api_mock: AsyncMock) -> None:
-    flow = AirzoneConfigFlow()
-    flow.hass = hass
-
-    api_mock.login = AsyncMock(return_value="")
-    api_mock.token = ""
-
-    result = _run(
-        flow.async_step_user(
-            user_input={
-                CONF_USERNAME: "user@example.com",
-                CONF_PASSWORD: "secret",
-                CONF_SCAN_INTERVAL: 15,
-                CONF_EXPOSE_PII: False,
-            }
-        )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=user_input
     )
 
-    assert result["type"] is HAFlowResultType.FORM
+    normalized_email = user_input[CONF_USERNAME].strip()
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == normalized_email
+    assert result["data"] == {CONF_USERNAME: normalized_email}
+    assert result["options"] == {
+        "user_token": fake_token,
+        CONF_SCAN_INTERVAL: 15,
+        CONF_EXPOSE_PII: True,
+        CONF_SLEEP_TIMEOUT_ENABLED: True,
+    }
+    assert CONF_ENABLE_HEAT_COOL not in result["options"]
+    assert login_api_class.instances[-1].cleared_password is True
+    assert login_api_class.instances[-1].password is None
+
+
+async def test_user_step_invalid_auth_from_api(
+    hass: HomeAssistant,
+    login_api_class: type[LoginAirzoneAPI],
+    fake_email: str,
+    fake_password: str,
+) -> None:
+    """A failed login should redisplay the form with invalid_auth."""
+    login_api_class.login_result = False
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_USERNAME: fake_email,
+            CONF_PASSWORD: fake_password,
+            CONF_SCAN_INTERVAL: 15,
+            CONF_EXPOSE_PII: False,
+            CONF_SLEEP_TIMEOUT_ENABLED: False,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-def test_user_step_cannot_connect(hass: HassStub, api_mock: AsyncMock) -> None:
-    flow = AirzoneConfigFlow()
-    flow.hass = hass
-
-    api_mock.login = AsyncMock(side_effect=RuntimeError("boom"))
-
-    result = _run(
-        flow.async_step_user(
-            user_input={
-                CONF_USERNAME: "user@example.com",
-                CONF_PASSWORD: "secret",
-                CONF_SCAN_INTERVAL: 15,
-                CONF_EXPOSE_PII: False,
-            }
-        )
+async def test_user_step_cannot_connect(
+    hass: HomeAssistant,
+    login_api_class: type[LoginAirzoneAPI],
+    fake_email: str,
+    fake_password: str,
+) -> None:
+    """Unexpected login errors should surface as cannot_connect."""
+    login_api_class.login_result = RuntimeError("boom")
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] is HAFlowResultType.FORM
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_USERNAME: fake_email,
+            CONF_PASSWORD: fake_password,
+            CONF_SCAN_INTERVAL: 15,
+            CONF_EXPOSE_PII: False,
+            CONF_SLEEP_TIMEOUT_ENABLED: False,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-def test_reauth_flow_success_updates_token(hass: HassStub, api_mock: AsyncMock) -> None:
-    entry = ConfigEntry(
-        domain=DOMAIN,
-        data={CONF_USERNAME: "user@example.com"},
+async def test_reauth_flow_success_updates_token(
+    hass: HomeAssistant,
+    dkn_config_entry_factory: Callable[..., MockConfigEntry],
+    login_api_class: type[LoginAirzoneAPI],
+    fake_password: str,
+    fake_token: str,
+) -> None:
+    """Reauth should refresh the token while preserving existing options."""
+    entry = dkn_config_entry_factory(
         options={
             "user_token": "old-token",
+            "hidden_key": "keep-me",
             CONF_SCAN_INTERVAL: 10,
             CONF_EXPOSE_PII: False,
-        },
-        unique_id="user@example.com",
+        }
     )
     entry.add_to_hass(hass)
 
-    flow = AirzoneConfigFlow()
-    flow.hass = hass
-    flow.context = {"source": SOURCE_REAUTH, "entry_id": entry.entry_id}
+    result = await entry.start_reauth_flow(hass)
 
-    result = _run(flow.async_step_reauth(entry.data))
-
-    assert result["type"] is HAFlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
-    result2 = _run(
-        flow.async_step_reauth_confirm(user_input={CONF_PASSWORD: "new-secret"})
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_PASSWORD: fake_password}
     )
 
-    assert result2["type"] is HAFlowResultType.ABORT
-    assert result2["reason"] == "reauth_successful"
-    assert entry.options["user_token"] == "login-token"
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.options["user_token"] == fake_token
+    assert entry.options["hidden_key"] == "keep-me"
     assert entry.options[CONF_SCAN_INTERVAL] == 10
     assert entry.options[CONF_EXPOSE_PII] is False
+    assert login_api_class.instances[-1].cleared_password is True
 
 
-def test_options_flow_updates_options_and_preserves_hidden_keys(hass: HassStub) -> None:
-    entry = ConfigEntry(
-        domain=DOMAIN,
-        data={CONF_USERNAME: "user@example.com"},
+async def test_options_flow_updates_options_and_preserves_hidden_keys(
+    hass: HomeAssistant,
+    dkn_config_entry_factory: Callable[..., MockConfigEntry],
+    fake_token: str,
+) -> None:
+    """Options flow should only update exposed options and keep hidden keys."""
+    entry = dkn_config_entry_factory(
         options={
-            "user_token": "tok-123",
+            "user_token": fake_token,
             "hidden_key": "keep-me",
             CONF_SCAN_INTERVAL: 10,
             CONF_EXPOSE_PII: False,
             CONF_ENABLE_HEAT_COOL: False,
             CONF_SLEEP_TIMEOUT_ENABLED: False,
-        },
-        unique_id="user@example.com",
+        }
     )
     entry.add_to_hass(hass)
 
-    flow = AirzoneOptionsFlow(entry)
-    flow.hass = hass
+    result = await hass.config_entries.options.async_init(entry.entry_id)
 
-    result = _run(flow.async_step_init(user_input=None))
-
-    assert result["type"] is HAFlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "init"
-    assert "data_schema" in result
 
-    result2 = _run(
-        flow.async_step_init(
-            user_input={
-                CONF_SCAN_INTERVAL: 20,
-                CONF_EXPOSE_PII: True,
-                CONF_ENABLE_HEAT_COOL: True,
-                CONF_SLEEP_TIMEOUT_ENABLED: True,
-            }
-        )
-    )
-
-    assert result2["type"] is HAFlowResultType.CREATE_ENTRY
-    new_options: dict[str, Any] = result2["data"]
-    assert new_options[CONF_SCAN_INTERVAL] == 20
-    assert new_options[CONF_EXPOSE_PII] is True
-    assert new_options[CONF_ENABLE_HEAT_COOL] is True
-    assert new_options[CONF_SLEEP_TIMEOUT_ENABLED] is True
-    assert new_options["user_token"] == "tok-123"
-    assert new_options["hidden_key"] == "keep-me"
-
-
-def test_options_flow_recomputes_heat_cool_when_cached_none(hass: HassStub) -> None:
-    entry = ConfigEntry(
-        domain=DOMAIN,
-        data={CONF_USERNAME: "user@example.com"},
-        options={
-            "user_token": "tok-123",
-            CONF_SCAN_INTERVAL: 10,
-            CONF_EXPOSE_PII: False,
-            CONF_ENABLE_HEAT_COOL: False,
-            CONF_SLEEP_TIMEOUT_ENABLED: False,
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_SCAN_INTERVAL: 20,
+            CONF_EXPOSE_PII: True,
+            CONF_ENABLE_HEAT_COOL: True,
+            CONF_SLEEP_TIMEOUT_ENABLED: True,
         },
-        unique_id="user@example.com",
     )
-    entry.add_to_hass(hass)
 
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_SCAN_INTERVAL] == 20
+    assert entry.options[CONF_EXPOSE_PII] is True
+    assert entry.options[CONF_ENABLE_HEAT_COOL] is True
+    assert entry.options[CONF_SLEEP_TIMEOUT_ENABLED] is True
+    assert entry.options["user_token"] == fake_token
+    assert entry.options["hidden_key"] == "keep-me"
+
+
+def test_options_flow_recomputes_heat_cool_when_cached_none(
+    hass: HomeAssistant,
+    dkn_config_entry_factory: Callable[..., MockConfigEntry],
+) -> None:
+    """Options flow should recompute HEAT_COOL support when cache is unknown."""
+    entry = dkn_config_entry_factory()
+    entry.add_to_hass(hass)
     hass.data[DOMAIN] = {
         entry.entry_id: {
             "heat_cool_supported": None,
-            "coordinator": types.SimpleNamespace(
-                data={"dev1": {"modes": "0011"}, "dev2": {"modes": "1111"}}
-            ),
+            "coordinator": type(
+                "Coordinator",
+                (),
+                {"data": {"dev1": {"modes": "0011"}, "dev2": {"modes": "1111"}}},
+            )(),
         }
     }
 
@@ -545,28 +289,26 @@ def test_options_flow_recomputes_heat_cool_when_cached_none(hass: HassStub) -> N
     assert hass.data[DOMAIN][entry.entry_id]["heat_cool_supported"] is True
 
 
-def test_options_flow_defaults_sleep_timeout_when_missing(hass: HassStub) -> None:
-    entry = ConfigEntry(
-        domain=DOMAIN,
-        data={CONF_USERNAME: "user@example.com"},
-        options={"user_token": "tok-abc", CONF_SCAN_INTERVAL: 10},
-        unique_id="user@example.com",
+async def test_options_flow_defaults_sleep_timeout_when_missing(
+    hass: HomeAssistant,
+    dkn_config_entry_factory: Callable[..., MockConfigEntry],
+    fake_token: str,
+) -> None:
+    """Older entries without sleep timeout option should default it to False."""
+    entry = dkn_config_entry_factory(
+        options={"user_token": fake_token, CONF_SCAN_INTERVAL: 10}
     )
     entry.add_to_hass(hass)
 
-    flow = AirzoneOptionsFlow(entry)
-    flow.hass = hass
-
-    result = _run(
-        flow.async_step_init(
-            user_input={
-                CONF_SCAN_INTERVAL: 12,
-                CONF_EXPOSE_PII: False,
-                CONF_ENABLE_HEAT_COOL: False,
-            }
-        )
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_SCAN_INTERVAL: 12,
+            CONF_EXPOSE_PII: False,
+            CONF_ENABLE_HEAT_COOL: False,
+        },
     )
 
-    assert result["type"] is HAFlowResultType.CREATE_ENTRY
-    options = result["data"]
-    assert options[CONF_SLEEP_TIMEOUT_ENABLED] is False
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_SLEEP_TIMEOUT_ENABLED] is False

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -291,12 +291,17 @@ def test_options_flow_recomputes_heat_cool_when_cached_none(
 
 async def test_options_flow_defaults_sleep_timeout_when_missing(
     hass: HomeAssistant,
-    dkn_config_entry_factory: Callable[..., MockConfigEntry],
     fake_token: str,
 ) -> None:
     """Older entries without sleep timeout option should default it to False."""
-    entry = dkn_config_entry_factory(
-        options={"user_token": fake_token, CONF_SCAN_INTERVAL: 10}
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="legacy-entry",
+        title="user@example.com",
+        data={CONF_USERNAME: "user@example.com"},
+        options={"user_token": fake_token, CONF_SCAN_INTERVAL: 10},
+        unique_id="user@example.com",
+        version=2,
     )
     entry.add_to_hass(hass)
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -32,6 +32,11 @@ class DummyCoordinator:
         }
 
 
+def _assert_redacted(value: object) -> None:
+    """Accept HA and local redaction sentinels."""
+    assert value in {"***", "**REDACTED**"}
+
+
 async def test_diagnostics_redacts_sensitive_fields(
     hass: HomeAssistant,
     dkn_config_entry_factory: Callable[..., MockConfigEntry],
@@ -48,15 +53,15 @@ async def test_diagnostics_redacts_sensitive_fields(
 
     result = await async_get_config_entry_diagnostics(hass, entry)
 
-    assert result["entry"]["options"]["user_token"] == "***"
+    _assert_redacted(result["entry"]["options"]["user_token"])
 
     coordinator_result = result["coordinator"]
     if isinstance(coordinator_result, dict):
         devices = coordinator_result.get("devices", {})
-        assert devices["device-1"]["user_token"] == "***"
-        assert devices["device-1"]["mac"] == "***"
-        assert devices["device-1"]["contactEmail"] == "***"
-        assert devices["device-1"]["metadata"]["gpsCoord"] == "***"
+        _assert_redacted(devices["device-1"]["user_token"])
+        _assert_redacted(devices["device-1"]["mac"])
+        _assert_redacted(devices["device-1"]["contactEmail"])
+        _assert_redacted(devices["device-1"]["metadata"]["gpsCoord"])
     else:
         assert coordinator_result == "***"
 
@@ -110,22 +115,22 @@ async def test_diagnostics_redacts_extended_pii_fields(
     result = await async_get_config_entry_diagnostics(hass, entry)
 
     options = result["entry"]["options"]
-    assert options["installation_id"] == "***"
-    assert options["time_zone"] == "***"
-    assert options["spot_name"] == "***"
-    assert options["complete_name"] == "***"
-    assert options["user_token"] == "***"
+    _assert_redacted(options["installation_id"])
+    _assert_redacted(options["time_zone"])
+    _assert_redacted(options["spot_name"])
+    _assert_redacted(options["complete_name"])
+    _assert_redacted(options["user_token"])
 
     coordinator_result = result["coordinator"]
     flattened = str(result)
 
     if isinstance(coordinator_result, dict):
         device_data = coordinator_result["devices"]["device-1"]
-        assert device_data["installation_id"] == "***"
-        assert device_data["spot_name"] == "***"
-        assert device_data["complete_name"] == "***"
-        assert device_data["time_zone"] == "***"
-        assert device_data["metadata"]["owner_id"] == "***"
+        _assert_redacted(device_data["installation_id"])
+        _assert_redacted(device_data["spot_name"])
+        _assert_redacted(device_data["complete_name"])
+        _assert_redacted(device_data["time_zone"])
+        _assert_redacted(device_data["metadata"]["owner_id"])
         assert device_data["ws_id"] == "ws-456"
         assert "ws-456" in flattened
     else:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -2,117 +2,15 @@
 
 from __future__ import annotations
 
-import asyncio
-import importlib.util
-import sys
-import types
-from copy import deepcopy
-from pathlib import Path
-from typing import Any
+from collections.abc import Callable
 
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-ha_module = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
-components_module = sys.modules.setdefault(
-    "homeassistant.components", types.ModuleType("homeassistant.components")
+from custom_components.airzoneclouddaikin.const import DOMAIN
+from custom_components.airzoneclouddaikin.diagnostics import (
+    async_get_config_entry_diagnostics,
 )
-ha_module.components = getattr(ha_module, "components", components_module)
-
-diagnostics_module = sys.modules.setdefault(
-    "homeassistant.components.diagnostics",
-    types.ModuleType("homeassistant.components.diagnostics"),
-)
-
-if not hasattr(diagnostics_module, "async_redact_data"):
-
-    def async_redact_data(data: Any, to_redact: set[str]) -> Any:
-        """Return a deep copy of data with selected keys redacted."""
-
-        def _walk(value: Any) -> Any:
-            if isinstance(value, dict):
-                return {
-                    key: ("***" if key in to_redact else _walk(val))
-                    for key, val in value.items()
-                }
-            if isinstance(value, list):
-                return [_walk(item) for item in value]
-            return value
-
-        return _walk(deepcopy(data))
-
-    diagnostics_module.async_redact_data = async_redact_data
-
-config_entries_module = sys.modules.setdefault(
-    "homeassistant.config_entries", types.ModuleType("homeassistant.config_entries")
-)
-
-if not hasattr(config_entries_module, "ConfigEntry"):
-
-    class ConfigEntry:  # pragma: no cover - stub only
-        pass
-
-    config_entries_module.ConfigEntry = ConfigEntry
-
-core_module = sys.modules.setdefault(
-    "homeassistant.core", types.ModuleType("homeassistant.core")
-)
-
-if not hasattr(core_module, "HomeAssistant"):
-
-    class HomeAssistant:  # pragma: no cover - stub only
-        data: dict[str, Any]
-
-    core_module.HomeAssistant = HomeAssistant
-
-custom_components_module = sys.modules.setdefault(
-    "custom_components", types.ModuleType("custom_components")
-)
-custom_components_module.__path__ = [str(ROOT / "custom_components")]
-
-airzone_package = sys.modules.setdefault(
-    "custom_components.airzoneclouddaikin",
-    types.ModuleType("custom_components.airzoneclouddaikin"),
-)
-airzone_package.__path__ = [str(ROOT / "custom_components" / "airzoneclouddaikin")]
-
-diagnostics_spec = importlib.util.spec_from_file_location(
-    "custom_components.airzoneclouddaikin.diagnostics",
-    ROOT / "custom_components" / "airzoneclouddaikin" / "diagnostics.py",
-)
-assert diagnostics_spec is not None and diagnostics_spec.loader is not None
-
-diagnostics_module_impl = importlib.util.module_from_spec(diagnostics_spec)
-sys.modules[diagnostics_spec.name] = diagnostics_module_impl
-diagnostics_spec.loader.exec_module(diagnostics_module_impl)
-async_get_config_entry_diagnostics = (
-    diagnostics_module_impl.async_get_config_entry_diagnostics
-)
-
-const_module = sys.modules.get("custom_components.airzoneclouddaikin.const")
-if const_module is None:
-    const_spec = importlib.util.spec_from_file_location(
-        "custom_components.airzoneclouddaikin.const",
-        ROOT / "custom_components" / "airzoneclouddaikin" / "const.py",
-    )
-    assert const_spec is not None and const_spec.loader is not None
-    const_module = importlib.util.module_from_spec(const_spec)
-    sys.modules[const_spec.name] = const_module
-    const_spec.loader.exec_module(const_module)
-
-DOMAIN = const_module.DOMAIN
-
-
-class DummyConfigEntry:
-    """Minimal config entry stub for diagnostics testing."""
-
-    def __init__(self) -> None:
-        self.entry_id = "test-entry"
-        self.title = "DKN Cloud"
-        self.data = {"user_email": "user@example.com", "device_ids": ["dev-1"]}
-        self.options = {"user_token": "token-value"}
-        self.version = 1
 
 
 class DummyCoordinator:
@@ -134,23 +32,21 @@ class DummyCoordinator:
         }
 
 
-class DummyHass:
-    """Minimal Home Assistant stub that exposes the integration data bucket."""
-
-    def __init__(self) -> None:
-        self.data: dict[str, Any] = {}
-
-
-def test_diagnostics_redacts_sensitive_fields() -> None:
+async def test_diagnostics_redacts_sensitive_fields(
+    hass: HomeAssistant,
+    dkn_config_entry_factory: Callable[..., MockConfigEntry],
+) -> None:
     """Sensitive identifiers must never leak through diagnostics output."""
-
-    hass = DummyHass()
-    entry = DummyConfigEntry()
+    entry = dkn_config_entry_factory(
+        data={"device_ids": ["dev-1"]},
+        options={"user_token": "token-value"},
+    )
+    entry.add_to_hass(hass)
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         "coordinator": DummyCoordinator()
     }
 
-    result = asyncio.run(async_get_config_entry_diagnostics(hass, entry))
+    result = await async_get_config_entry_diagnostics(hass, entry)
 
     assert result["entry"]["options"]["user_token"] == "***"
 
@@ -174,27 +70,27 @@ def test_diagnostics_redacts_sensitive_fields() -> None:
     assert '"latitude"' not in flattened
 
 
-def test_diagnostics_redacts_extended_pii_fields() -> None:
+async def test_diagnostics_redacts_extended_pii_fields(
+    hass: HomeAssistant,
+    dkn_config_entry_factory: Callable[..., MockConfigEntry],
+) -> None:
     """Redaction should cover additional sensitive fields in entries and devices."""
-
-    hass = DummyHass()
-    entry = DummyConfigEntry()
-    entry.data.update(
-        {
+    entry = dkn_config_entry_factory(
+        data={
             "installation_id": "install-123",
             "spot_name": "My Home",
             "complete_name": "John Doe",
             "time_zone": "Europe/Madrid",
-        }
-    )
-    entry.options.update(
-        {
+        },
+        options={
             "installation_id": "install-123",
             "time_zone": "Europe/Madrid",
             "spot_name": "My Home",
             "complete_name": "John Doe",
-        }
+            "user_token": "token-value",
+        },
     )
+    entry.add_to_hass(hass)
 
     coordinator = DummyCoordinator()
     coordinator.data["device-1"].update(
@@ -211,7 +107,7 @@ def test_diagnostics_redacts_extended_pii_fields() -> None:
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {"coordinator": coordinator}
 
-    result = asyncio.run(async_get_config_entry_diagnostics(hass, entry))
+    result = await async_get_config_entry_diagnostics(hass, entry)
 
     options = result["entry"]["options"]
     assert options["installation_id"] == "***"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -2,171 +2,66 @@
 
 from __future__ import annotations
 
-import asyncio
-import importlib.util
-import sys
-import types
 from collections.abc import Callable
-from pathlib import Path
 from typing import Any
 
 import pytest
+from homeassistant.core import HomeAssistant
 
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
-# Stub minimal external modules to import the helper without full Home Assistant deps.
-aiohttp_stub = types.ModuleType("aiohttp")
-
-
-class _ClientResponseError(Exception):
-    def __init__(self, *args: object, **kwargs: object) -> None:
-        super().__init__(*args)
-
-
-aiohttp_stub.ClientResponseError = _ClientResponseError
-sys.modules.setdefault("aiohttp", aiohttp_stub)
-
-ha_module = types.ModuleType("homeassistant")
-helpers_module = types.ModuleType("homeassistant.helpers")
-core_module = types.ModuleType("homeassistant.core")
-
-
-class _HomeAssistant:
-    loop: Any
-    data: dict[str, Any]
-
-
-core_module.HomeAssistant = _HomeAssistant
-
-helpers_event_module = types.ModuleType("homeassistant.helpers.event")
-
-
-def _async_call_later(*_args: Any, **_kwargs: Any) -> Callable[[], None]:
-    raise NotImplementedError
-
-
-helpers_event_module.async_call_later = _async_call_later
-helpers_update_module = types.ModuleType("homeassistant.helpers.update_coordinator")
-
-
-class _DataUpdateCoordinator:  # pragma: no cover - stub only
-    pass
-
-
-helpers_update_module.DataUpdateCoordinator = _DataUpdateCoordinator
-
-ha_module.helpers = helpers_module
-sys.modules.setdefault("homeassistant", ha_module)
-sys.modules.setdefault("homeassistant.core", core_module)
-helpers_module.event = helpers_event_module
-helpers_module.update_coordinator = helpers_update_module
-sys.modules.setdefault("homeassistant.helpers", helpers_module)
-sys.modules.setdefault("homeassistant.helpers.event", helpers_event_module)
-sys.modules.setdefault(
-    "homeassistant.helpers.update_coordinator", helpers_update_module
+from custom_components.airzoneclouddaikin import helpers
+from custom_components.airzoneclouddaikin.const import DOMAIN
+from custom_components.airzoneclouddaikin.helpers import (
+    async_auto_exit_sleep_if_needed,
+    optimistic_get,
+    optimistic_invalidate,
+    optimistic_set,
 )
 
-custom_components_module = types.ModuleType("custom_components")
-custom_components_module.__path__ = [str(ROOT / "custom_components")]
-sys.modules.setdefault("custom_components", custom_components_module)
 
-airzone_package = types.ModuleType("custom_components.airzoneclouddaikin")
-airzone_package.__path__ = [str(ROOT / "custom_components" / "airzoneclouddaikin")]
-sys.modules.setdefault("custom_components.airzoneclouddaikin", airzone_package)
-
-helpers_spec = importlib.util.spec_from_file_location(
-    "custom_components.airzoneclouddaikin.helpers",
-    ROOT / "custom_components" / "airzoneclouddaikin" / "helpers.py",
-)
-helpers_module = importlib.util.module_from_spec(helpers_spec)
-assert helpers_spec is not None and helpers_spec.loader is not None
-sys.modules[helpers_spec.name] = helpers_module
-helpers_spec.loader.exec_module(helpers_module)
-optimistic_get = helpers_module.optimistic_get
-optimistic_set = helpers_module.optimistic_set
-optimistic_invalidate = helpers_module.optimistic_invalidate
-async_auto_exit_sleep_if_needed = helpers_module.async_auto_exit_sleep_if_needed
-DOMAIN = helpers_module.DOMAIN
-
-
-class _LoopStub:
-    """Event loop stub exposing monotonic time control."""
-
-    def __init__(self) -> None:
-        self._time = 0.0
-
-    def time(self) -> float:
-        return self._time
-
-    def advance(self, seconds: float) -> None:
-        self._time += seconds
-
-
-class DummyHass:
-    """Minimal Home Assistant stub for helper testing."""
-
-    def __init__(self) -> None:
-        self.loop = _LoopStub()
-        self.data: dict[str, dict[str, dict[str, Any]]] = {}
-
-
-@pytest.fixture
-def hass_stub() -> DummyHass:
-    return DummyHass()
-
-
-def test_optimistic_overlay_value_before_expiration(hass_stub: DummyHass) -> None:
+def test_optimistic_overlay_value_before_expiration(hass: HomeAssistant) -> None:
     """Overlay reads should return the optimistic value prior to expiring."""
+    optimistic_set(hass, "entry", "device", "temp", 23, ttl=5)
 
-    optimistic_set(hass_stub, "entry", "device", "temp", 23, ttl=5)
+    result = optimistic_get(hass, "entry", "device", "temp", backend_value=18)
 
-    result = optimistic_get(hass_stub, "entry", "device", "temp", backend_value=18)
     assert result == 23
 
 
-def test_optimistic_overlay_expires_after_ttl(hass_stub: DummyHass) -> None:
+def test_optimistic_overlay_expires_after_ttl(hass: HomeAssistant) -> None:
     """Overlay should fall back to backend once the TTL has elapsed."""
+    optimistic_set(hass, "entry", "device", "temp", 22, ttl=0)
 
-    optimistic_set(hass_stub, "entry", "device", "temp", 22, ttl=2)
+    result = optimistic_get(hass, "entry", "device", "temp", backend_value=17)
 
-    hass_stub.loop.advance(2.5)
-    result = optimistic_get(hass_stub, "entry", "device", "temp", backend_value=17)
     assert result == 17
-    optimistic_bucket = hass_stub.data["airzoneclouddaikin"]["entry"].get(
-        "optimistic", {}
-    )
+    optimistic_bucket = hass.data["airzoneclouddaikin"]["entry"].get("optimistic", {})
     assert "device" not in optimistic_bucket
 
 
-def test_optimistic_overlay_invalidate_removes_value(hass_stub: DummyHass) -> None:
+def test_optimistic_overlay_invalidate_removes_value(hass: HomeAssistant) -> None:
     """Explicit invalidation should clear overlays immediately."""
+    optimistic_set(hass, "entry", "device", "mode", "cool", ttl=5)
+    optimistic_invalidate(hass, "entry", "device", "mode")
 
-    optimistic_set(hass_stub, "entry", "device", "mode", "cool", ttl=5)
-    optimistic_invalidate(hass_stub, "entry", "device", "mode")
+    result = optimistic_get(hass, "entry", "device", "mode", backend_value="auto")
 
-    result = optimistic_get(hass_stub, "entry", "device", "mode", backend_value="auto")
     assert result == "auto"
 
 
-def test_optimistic_overlay_malformed_expiration(hass_stub: DummyHass) -> None:
+def test_optimistic_overlay_malformed_expiration(hass: HomeAssistant) -> None:
     """Malformed overlay metadata should fall back to the backend and self-heal."""
+    optimistic_set(hass, "entry", "device", "temp", 21, ttl=5)
 
-    optimistic_set(hass_stub, "entry", "device", "temp", 21, ttl=5)
-
-    optimistic_bucket = hass_stub.data["airzoneclouddaikin"]["entry"].setdefault(
+    optimistic_bucket = hass.data["airzoneclouddaikin"]["entry"].setdefault(
         "optimistic", {}
     )
     overlay = optimistic_bucket.setdefault("device", {}).setdefault("temp", {})
     overlay["expires"] = "bad"
 
-    result = optimistic_get(hass_stub, "entry", "device", "temp", backend_value=19)
-    assert result == 19
+    result = optimistic_get(hass, "entry", "device", "temp", backend_value=19)
 
-    optimistic_bucket = hass_stub.data["airzoneclouddaikin"]["entry"].get(
-        "optimistic", {}
-    )
+    assert result == 19
+    optimistic_bucket = hass.data["airzoneclouddaikin"]["entry"].get("optimistic", {})
     assert "device" not in optimistic_bucket
 
 
@@ -177,6 +72,7 @@ class DummyApi:
         self.calls: list[tuple[str, str]] = []
 
     async def async_set_scenary(self, device_id: str, scenary: str) -> None:
+        """Record a scenary write."""
         self.calls.append((device_id, scenary))
 
 
@@ -185,14 +81,18 @@ class DummyCoordinator:
 
     def __init__(self, api: DummyApi) -> None:
         self.api = api
+        self.refreshes = 0
 
-    def async_request_refresh(self) -> None:
-        return None
+    async def async_request_refresh(self) -> None:
+        """Record refresh requests."""
+        self.refreshes += 1
 
 
-def test_auto_exit_sleep_when_expired(
-    hass_stub: DummyHass, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.asyncio
+async def test_auto_exit_sleep_when_expired(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Expired sleep scenary should auto-exit to occupied and schedule refresh."""
     scheduled: list[Callable[[], None]] = []
 
     def _schedule_stub(_hass: Any, _delay: float, _callback: Any) -> Callable[[], None]:
@@ -202,7 +102,7 @@ def test_auto_exit_sleep_when_expired(
         scheduled.append(_cancel)
         return _cancel
 
-    monkeypatch.setattr(helpers_module, "async_call_later", _schedule_stub)
+    monkeypatch.setattr(helpers, "async_call_later", _schedule_stub)
 
     api = DummyApi()
     coordinator = DummyCoordinator(api)
@@ -210,30 +110,30 @@ def test_auto_exit_sleep_when_expired(
     entry_id = "entry-1"
     device = {"scenary": "sleep", "sleep_expired": True}
 
-    asyncio.run(
-        async_auto_exit_sleep_if_needed(
-            hass_stub,
-            entry_id=entry_id,
-            device_id=device_id,
-            device=device,
-            coordinator=coordinator,
-            reason="test",
-            is_device_on=lambda: False,
-            allow_away_handling=False,
-        )
+    await async_auto_exit_sleep_if_needed(
+        hass,
+        entry_id=entry_id,
+        device_id=device_id,
+        device=device,
+        coordinator=coordinator,
+        reason="test",
+        is_device_on=lambda: False,
+        allow_away_handling=False,
     )
 
     assert api.calls == [(device_id, "occupied")]
-    optimistic_bucket = hass_stub.data[DOMAIN][entry_id]["optimistic"]
+    optimistic_bucket = hass.data[DOMAIN][entry_id]["optimistic"]
     overlay = optimistic_bucket[device_id]["scenary"]["value"]
     assert overlay == "occupied"
-    assert callable(hass_stub.data[DOMAIN][entry_id]["pending_refresh"])
+    assert callable(hass.data[DOMAIN][entry_id]["pending_refresh"])
     assert scheduled
 
 
-def test_auto_exit_sleep_skips_active_session(
-    hass_stub: DummyHass, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.asyncio
+async def test_auto_exit_sleep_skips_active_session(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Active sleep sessions should not auto-exit."""
     scheduled: list[Callable[[], None]] = []
 
     def _schedule_stub(_hass: Any, _delay: float, _callback: Any) -> Callable[[], None]:
@@ -243,7 +143,7 @@ def test_auto_exit_sleep_skips_active_session(
         scheduled.append(_cancel)
         return _cancel
 
-    monkeypatch.setattr(helpers_module, "async_call_later", _schedule_stub)
+    monkeypatch.setattr(helpers, "async_call_later", _schedule_stub)
 
     api = DummyApi()
     coordinator = DummyCoordinator(api)
@@ -251,23 +151,21 @@ def test_auto_exit_sleep_skips_active_session(
     entry_id = "entry-2"
     device = {"scenary": "sleep", "sleep_expired": False}
 
-    asyncio.run(
-        async_auto_exit_sleep_if_needed(
-            hass_stub,
-            entry_id=entry_id,
-            device_id=device_id,
-            device=device,
-            coordinator=coordinator,
-            reason="test",
-            is_device_on=lambda: True,
-            allow_away_handling=False,
-        )
+    await async_auto_exit_sleep_if_needed(
+        hass,
+        entry_id=entry_id,
+        device_id=device_id,
+        device=device,
+        coordinator=coordinator,
+        reason="test",
+        is_device_on=lambda: True,
+        allow_away_handling=False,
     )
 
     assert api.calls == []
     optimistic_bucket = (
-        hass_stub.data.get(DOMAIN, {}).get(entry_id, {}).get("optimistic", {})
+        hass.data.get(DOMAIN, {}).get(entry_id, {}).get("optimistic", {})
     )
     assert device_id not in optimistic_bucket
-    assert "pending_refresh" not in hass_stub.data.get(DOMAIN, {}).get(entry_id, {})
+    assert "pending_refresh" not in hass.data.get(DOMAIN, {}).get(entry_id, {})
     assert not scheduled

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,253 +1,26 @@
-"""Notification formatting and coordinator listener coverage."""
+"""Notification formatting, coordinator update, setup, and unload coverage."""
 
 from __future__ import annotations
 
 import asyncio
-import sys
-import types
-from datetime import datetime, timedelta, timezone
-from pathlib import Path
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import ANY, AsyncMock, Mock
 
 import pytest
-
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
-for key in list(sys.modules):
-    if key.startswith("custom_components.airzoneclouddaikin"):
-        sys.modules.pop(key, None)
-
-UTC = getattr(datetime, "UTC", timezone.utc)  # noqa: UP017
-
-try:
-    from aiohttp import (  # type: ignore[import-untyped]
-        ClientConnectorError,
-        ClientResponseError,
-        ClientSession,
-        ClientTimeout,
-    )
-except ImportError, ModuleNotFoundError:  # pragma: no cover - handled by CI deps
-    aiohttp_module = types.ModuleType("aiohttp")
-    sys.modules["aiohttp"] = aiohttp_module
-
-    class ClientResponseError(Exception):
-        """Minimal aiohttp ClientResponseError placeholder."""
-
-    class ClientConnectorError(Exception):
-        """Minimal aiohttp ClientConnectorError placeholder."""
-
-    class ClientSession:  # pragma: no cover - placeholder
-        pass
-
-    class ClientTimeout:
-        """Minimal aiohttp ClientTimeout placeholder."""
-
-        def __init__(self, *_: Any, **__: Any) -> None:
-            return None
-
-    aiohttp_module.ClientResponseError = ClientResponseError
-    aiohttp_module.ClientConnectorError = ClientConnectorError
-    aiohttp_module.ClientSession = ClientSession
-    aiohttp_module.ClientTimeout = ClientTimeout
-
-# ---------------------------------------------------------------------------
-# Minimal Home Assistant shims so the package import works without HA
-# ---------------------------------------------------------------------------
-ha_module = types.ModuleType("homeassistant")
-sys.modules["homeassistant"] = ha_module
-
-components_module = types.ModuleType("homeassistant.components")
-persistent_notification_module = types.ModuleType(
-    "homeassistant.components.persistent_notification"
-)
-components_module.persistent_notification = persistent_notification_module
-sys.modules["homeassistant.components"] = components_module
-sys.modules["homeassistant.components.persistent_notification"] = (
-    persistent_notification_module
-)
-ha_module.components = components_module
-
-config_entries_module = types.ModuleType("homeassistant.config_entries")
-config_entries_module.SOURCE_REAUTH = "reauth"
-
-
-class ConfigEntry:  # pragma: no cover - used for import wiring
-    def __init__(self) -> None:
-        self.entry_id = "entry-1"
-        self.data: dict[str, Any] = {}
-        self.options: dict[str, Any] = {}
-        self.unique_id: str | None = None
-        self.version = 1
-        self._unload: list[Any] = []
-
-    def async_on_unload(self, func: Any) -> None:
-        self._unload.append(func)
-
-    def add_update_listener(self, listener: Any) -> Any:
-        return listener
-
-
-config_entries_module.ConfigEntry = ConfigEntry
-sys.modules["homeassistant.config_entries"] = config_entries_module
-ha_module.config_entries = config_entries_module
-
-const_module = types.ModuleType("homeassistant.const")
-const_module.CONF_USERNAME = "username"
-sys.modules["homeassistant.const"] = const_module
-ha_module.const = const_module
-
-core_module = types.ModuleType("homeassistant.core")
-
-
-class HomeAssistant:  # pragma: no cover - placeholder
-    pass
-
-
-core_module.HomeAssistant = HomeAssistant
-sys.modules["homeassistant.core"] = core_module
-ha_module.core = core_module
-
-exceptions_module = types.ModuleType("homeassistant.exceptions")
-
-
-class HomeAssistantError(Exception):
-    """Minimal Home Assistant error placeholder."""
-
-
-class ConfigEntryAuthFailed(HomeAssistantError):
-    """Minimal auth failure placeholder."""
-
-
-exceptions_module.HomeAssistantError = HomeAssistantError
-exceptions_module.ConfigEntryAuthFailed = ConfigEntryAuthFailed
-sys.modules["homeassistant.exceptions"] = exceptions_module
-ha_module.exceptions = exceptions_module
-
-helpers_module = types.ModuleType("homeassistant.helpers")
-sys.modules["homeassistant.helpers"] = helpers_module
-
-aiohttp_client_module = types.ModuleType("homeassistant.helpers.aiohttp_client")
-
-
-def async_get_clientsession(*_: Any, **__: Any) -> None:
-    return None
-
-
-aiohttp_client_module.async_get_clientsession = async_get_clientsession
-helpers_module.aiohttp_client = aiohttp_client_module
-sys.modules["homeassistant.helpers.aiohttp_client"] = aiohttp_client_module
-
-event_module = types.ModuleType("homeassistant.helpers.event")
-
-
-async def async_call_later(*_: Any, **__: Any) -> None:
-    return None
-
-
-event_module.async_call_later = async_call_later
-helpers_module.event = event_module
-sys.modules["homeassistant.helpers.event"] = event_module
-
-translation_module = types.ModuleType("homeassistant.helpers.translation")
-
-
-async def async_get_translations(*_: Any, **__: Any) -> dict[str, str]:
-    return {}
-
-
-translation_module.async_get_translations = async_get_translations
-helpers_module.translation = translation_module
-sys.modules["homeassistant.helpers.translation"] = translation_module
-
-update_coordinator_module = types.ModuleType("homeassistant.helpers.update_coordinator")
-
-
-class UpdateFailed(Exception):
-    """Placeholder for coordinator update failures."""
-
-
-class DataUpdateCoordinator:
-    """Minimal coordinator stub that registers listeners."""
-
-    def __init__(
-        self, hass: Any, *_: Any, update_method: Any = None, **__: Any
-    ) -> None:
-        self.hass = hass
-        self.update_method = update_method
-        self.data: dict[str, Any] = {}
-        self._listeners: list[Any] = []
-
-    async def async_config_entry_first_refresh(self) -> None:
-        if self.update_method is not None:
-            self.data = await self.update_method()
-
-    def async_add_listener(self, listener: Any) -> Any:
-        self._listeners.append(listener)
-
-        def _unsub() -> None:
-            if listener in self._listeners:
-                self._listeners.remove(listener)
-
-        return _unsub
-
-    def async_request_refresh(self) -> None:
-        return None
-
-    def __class_getitem__(cls, item: object) -> type:
-        return cls
-
-
-update_coordinator_module.UpdateFailed = UpdateFailed
-update_coordinator_module.DataUpdateCoordinator = DataUpdateCoordinator
-helpers_module.update_coordinator = update_coordinator_module
-sys.modules["homeassistant.helpers.update_coordinator"] = update_coordinator_module
-
-util_module = types.ModuleType("homeassistant.util")
-dt_module = types.ModuleType("homeassistant.util.dt")
-util_module.dt = dt_module
-helpers_module.util = util_module
-sys.modules["homeassistant.util"] = util_module
-sys.modules["homeassistant.util.dt"] = dt_module
-
-
-def utcnow() -> datetime:
-    return datetime.now(UTC)
-
-
-def parse_datetime(value: str) -> datetime | None:
-    try:
-        parsed = datetime.fromisoformat(value)
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=UTC)
-    return parsed
-
-
-def as_utc(value: datetime) -> datetime:
-    if value.tzinfo is None:
-        return value.replace(tzinfo=UTC)
-    return value.astimezone(UTC)
-
-
-def as_local(value: datetime) -> datetime:
-    if value.tzinfo is None:
-        return value.replace(tzinfo=UTC)
-    return value
-
-
-dt_module.utcnow = utcnow
-dt_module.parse_datetime = parse_datetime
-dt_module.as_utc = as_utc
-dt_module.as_local = as_local
-
-ha_module.helpers = helpers_module
-
-import custom_components.airzoneclouddaikin as integration  # noqa: E402
-from custom_components.airzoneclouddaikin.const import (  # noqa: E402
+from aiohttp import ClientResponseError
+from aiohttp.client_reqrep import RequestInfo
+from homeassistant.const import CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from multidict import CIMultiDict
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from yarl import URL
+
+import custom_components.airzoneclouddaikin as integration
+from custom_components.airzoneclouddaikin.config_flow import CONF_SCAN_INTERVAL
+from custom_components.airzoneclouddaikin.const import (
     DOMAIN,
     OFFLINE_DEBOUNCE_SEC,
     ONLINE_BANNER_TTL_SEC,
@@ -255,65 +28,113 @@ from custom_components.airzoneclouddaikin.const import (  # noqa: E402
 )
 
 
-class DummyConfigEntries:
-    async def async_forward_entry_setups(self, *_: Any, **__: Any) -> None:
-        return None
+class FakeSetupAPI:
+    """Fake API used by setup and notification tests."""
 
-    async def async_forward_entry_unload(self, *_: Any, **__: Any) -> bool:
-        return True
+    installations: list[dict[str, Any]] = []
+    devices_by_installation: dict[str, list[dict[str, Any]]] = {}
+    instances: list[FakeSetupAPI] = []
 
-    async def async_reload(self, *_: Any, **__: Any) -> None:
-        return None
+    def __init__(
+        self,
+        username: str | None,
+        session: Any,
+        *,
+        password: str | None = None,
+        token: str | None = None,
+    ) -> None:
+        self.username = username
+        self.session = session
+        self.password = password
+        self.token = token
+        self.fetch_installations = AsyncMock(return_value=list(self.installations))
 
-    def async_entries(self, *_: Any, **__: Any) -> list[Any]:
-        return []
+        async def _fetch_devices(installation_id: str) -> list[dict[str, Any]]:
+            return list(self.devices_by_installation.get(str(installation_id), []))
+
+        self.fetch_devices = AsyncMock(side_effect=_fetch_devices)
+        self.async_set_scenary = AsyncMock()
+        self.send_event = AsyncMock()
+        self.put_device_fields = AsyncMock()
+        self.instances.append(self)
 
 
-class DummyHass:
-    def __init__(self) -> None:
-        self.data: dict[str, Any] = {}
-        self.config = types.SimpleNamespace(language="en")
-        self.config_entries = DummyConfigEntries()
+@pytest.fixture
+def setup_api_class(monkeypatch: pytest.MonkeyPatch) -> type[FakeSetupAPI]:
+    """Patch integration setup to use a fake API class."""
+    FakeSetupAPI.installations = []
+    FakeSetupAPI.devices_by_installation = {}
+    FakeSetupAPI.instances = []
+    monkeypatch.setattr(integration, "AirzoneAPI", FakeSetupAPI)
+    return FakeSetupAPI
 
 
-def _make_entry() -> ConfigEntry:
-    entry = ConfigEntry()
-    entry.data = {const_module.CONF_USERNAME: "user@example.com"}
-    entry.options = {"user_token": "token", "scan_interval": 10}
-    return entry
+def _client_response_error(status: int) -> ClientResponseError:
+    """Create a ClientResponseError with minimal request info."""
+    request_info = RequestInfo(
+        URL("https://example.com"),
+        "GET",
+        CIMultiDict(),
+        URL("https://example.com"),
+    )
+    return ClientResponseError(request_info, history=(), status=status)
+
+
+async def _setup_entry(
+    hass: HomeAssistant,
+    entry: MockConfigEntry,
+    setup_api_class: type[FakeSetupAPI],
+    *,
+    installations: list[dict[str, Any]] | None = None,
+    devices_by_installation: dict[str, list[dict[str, Any]]] | None = None,
+) -> None:
+    """Set up the integration entry with a fake API snapshot."""
+    setup_api_class.installations = installations or []
+    setup_api_class.devices_by_installation = devices_by_installation or {}
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
 
 def test_fmt_includes_name_in_message() -> None:
+    """Notification templates should interpolate known placeholders."""
     strings = {
         "offline": {
             "title": "{name} offline",
             "message": "{name} lost connection at {ts_local}.",
         }
     }
+
     title, message = integration._fmt(
         strings, "offline", "Living Room", "10:01", None, None
     )
+
     assert title == "Living Room offline"
     assert message == "Living Room lost connection at 10:01."
 
 
 def test_fmt_missing_values_with_format_specifier() -> None:
+    """Missing placeholder values should format to a neutral dash."""
     strings = {
         "offline": {
             "title": "{name} offline",
             "message": "Last seen {last_iso} ({mins:d} minutes ago).",
         }
     }
+
     title, message = integration._fmt(
         strings, "offline", "Living Room", "10:01", None, None
     )
+
     assert title == "Living Room offline"
-    assert message == "Last seen — (— minutes ago)."
+    assert message == "Last seen \u2014 (\u2014 minutes ago)."
 
 
 def test_fmt_warns_and_falls_back_on_malformed_templates(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    """Malformed templates should fall back once per kind."""
     integration._NOTIFY_FMT_FALLBACK_LOGGED.clear()
     strings = {
         "offline": {
@@ -333,22 +154,47 @@ def test_fmt_warns_and_falls_back_on_malformed_templates(
 
 
 @pytest.mark.asyncio
-async def test_offline_notification_after_debounce(
-    monkeypatch: pytest.MonkeyPatch,
+async def test_setup_unload_smoke_with_fake_snapshot(
+    hass: HomeAssistant,
+    dkn_config_entry_factory: Callable[..., MockConfigEntry],
+    setup_api_class: type[FakeSetupAPI],
+    sample_device: dict[str, Any],
 ) -> None:
-    hass = DummyHass()
-    entry = _make_entry()
+    """Config entry setup should load, store coordinator data, and unload."""
+    entry = dkn_config_entry_factory()
 
-    monkeypatch.setattr(
-        integration.AirzoneAPI, "fetch_installations", AsyncMock(return_value=[])
+    await _setup_entry(
+        hass,
+        entry,
+        setup_api_class,
+        installations=[{"installation_id": "install-123"}],
+        devices_by_installation={"install-123": [sample_device]},
     )
 
-    await integration.async_setup_entry(hass, entry)
+    bucket = hass.data[DOMAIN][entry.entry_id]
+    assert bucket["coordinator"].data == {"dev1": sample_device}
+    assert bucket["api"] is setup_api_class.instances[-1]
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.entry_id not in hass.data.get(DOMAIN, {})
+
+
+@pytest.mark.asyncio
+async def test_offline_notification_after_debounce(
+    hass: HomeAssistant,
+    dkn_config_entry_factory: Callable[..., MockConfigEntry],
+    setup_api_class: type[FakeSetupAPI],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Offline notification should appear only after debounce."""
+    entry = dkn_config_entry_factory()
+    await _setup_entry(hass, entry, setup_api_class)
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
     listener = coordinator._listeners[-1]
 
-    integration.persistent_notification.async_create = Mock()
-    integration.persistent_notification.async_dismiss = Mock()
+    monkeypatch.setattr(integration.persistent_notification, "async_create", Mock())
+    monkeypatch.setattr(integration.persistent_notification, "async_dismiss", Mock())
 
     base = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
     old = base - timedelta(seconds=integration._OFFLINE_STALE_SECONDS + 10)
@@ -374,25 +220,23 @@ async def test_offline_notification_after_debounce(
 
 @pytest.mark.asyncio
 async def test_online_notification_dismisses_offline_and_schedules_banner(
+    hass: HomeAssistant,
+    dkn_config_entry_factory: Callable[..., MockConfigEntry],
+    setup_api_class: type[FakeSetupAPI],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    hass = DummyHass()
-    entry = _make_entry()
-
-    monkeypatch.setattr(
-        integration.AirzoneAPI, "fetch_installations", AsyncMock(return_value=[])
-    )
-
-    await integration.async_setup_entry(hass, entry)
+    """Online transition should dismiss offline and schedule banner cleanup."""
+    entry = dkn_config_entry_factory()
+    await _setup_entry(hass, entry, setup_api_class)
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
     listener = coordinator._listeners[-1]
 
-    integration.persistent_notification.async_create = Mock()
-    integration.persistent_notification.async_dismiss = Mock()
+    monkeypatch.setattr(integration.persistent_notification, "async_create", Mock())
+    monkeypatch.setattr(integration.persistent_notification, "async_dismiss", Mock())
 
     scheduled: list[tuple[float, Any]] = []
 
-    def fake_call_later(hass_arg: Any, delay: float, action: Any) -> Any:
+    def fake_call_later(hass_arg: Any, delay: float, action: Any) -> Callable[[], None]:
         scheduled.append((delay, action))
 
         def cancel() -> None:
@@ -445,21 +289,19 @@ async def test_online_notification_dismisses_offline_and_schedules_banner(
 
 @pytest.mark.asyncio
 async def test_listener_never_raises_on_unknown_placeholders(
+    hass: HomeAssistant,
+    dkn_config_entry_factory: Callable[..., MockConfigEntry],
+    setup_api_class: type[FakeSetupAPI],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    hass = DummyHass()
-    entry = _make_entry()
-
-    monkeypatch.setattr(
-        integration.AirzoneAPI, "fetch_installations", AsyncMock(return_value=[])
-    )
-
-    await integration.async_setup_entry(hass, entry)
+    """Unknown placeholders in translated templates should not crash listener."""
+    entry = dkn_config_entry_factory()
+    await _setup_entry(hass, entry, setup_api_class)
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
     listener = coordinator._listeners[-1]
 
-    integration.persistent_notification.async_create = Mock()
-    integration.persistent_notification.async_dismiss = Mock()
+    monkeypatch.setattr(integration.persistent_notification, "async_create", Mock())
+    monkeypatch.setattr(integration.persistent_notification, "async_dismiss", Mock())
 
     hass.data[DOMAIN][entry.entry_id]["notify_strings"] = {
         "offline": {
@@ -485,26 +327,24 @@ async def test_listener_never_raises_on_unknown_placeholders(
 
 @pytest.mark.asyncio
 async def test_online_banner_second_transition_cancels_previous(
+    hass: HomeAssistant,
+    dkn_config_entry_factory: Callable[..., MockConfigEntry],
+    setup_api_class: type[FakeSetupAPI],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    hass = DummyHass()
-    entry = _make_entry()
-
-    monkeypatch.setattr(
-        integration.AirzoneAPI, "fetch_installations", AsyncMock(return_value=[])
-    )
-
-    await integration.async_setup_entry(hass, entry)
+    """A second online transition should cancel the previous online banner."""
+    entry = dkn_config_entry_factory()
+    await _setup_entry(hass, entry, setup_api_class)
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
     listener = coordinator._listeners[-1]
 
-    integration.persistent_notification.async_create = Mock()
-    integration.persistent_notification.async_dismiss = Mock()
+    monkeypatch.setattr(integration.persistent_notification, "async_create", Mock())
+    monkeypatch.setattr(integration.persistent_notification, "async_dismiss", Mock())
 
     events: list[str] = []
     cancels: list[Mock] = []
 
-    def fake_call_later(hass_arg: Any, delay: float, action: Any) -> Any:
+    def fake_call_later(hass_arg: Any, delay: float, action: Any) -> Mock:
         label = f"{len(cancels) + 1}"
         events.append(f"schedule-{label}")
 
@@ -551,21 +391,18 @@ async def test_online_banner_second_transition_cancels_previous(
 
 @pytest.mark.asyncio
 async def test_online_to_offline_cancels_online_banner(
+    hass: HomeAssistant,
+    dkn_config_entry_factory: Callable[..., MockConfigEntry],
+    setup_api_class: type[FakeSetupAPI],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    hass = DummyHass()
-    entry = _make_entry()
+    """Going offline should cancel any pending online banner."""
+    entry = dkn_config_entry_factory()
+    await _setup_entry(hass, entry, setup_api_class)
+    listener = hass.data[DOMAIN][entry.entry_id]["coordinator"]._listeners[-1]
 
-    monkeypatch.setattr(
-        integration.AirzoneAPI, "fetch_installations", AsyncMock(return_value=[])
-    )
-
-    await integration.async_setup_entry(hass, entry)
-    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
-    listener = coordinator._listeners[-1]
-
-    integration.persistent_notification.async_create = Mock()
-    integration.persistent_notification.async_dismiss = Mock()
+    monkeypatch.setattr(integration.persistent_notification, "async_create", Mock())
+    monkeypatch.setattr(integration.persistent_notification, "async_dismiss", Mock())
 
     cancel = Mock()
     notify_state = hass.data[DOMAIN][entry.entry_id]["notify_state"]
@@ -578,6 +415,7 @@ async def test_online_to_offline_cancels_online_banner(
 
     base = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
     old = base - timedelta(seconds=integration._OFFLINE_STALE_SECONDS + 10)
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
     coordinator.data = {"dev-6": {"name": "Unit 6", "connection_date": old.isoformat()}}
 
     monkeypatch.setattr(integration.dt_util, "utcnow", lambda: base)
@@ -590,21 +428,19 @@ async def test_online_to_offline_cancels_online_banner(
 
 @pytest.mark.asyncio
 async def test_removed_device_cleans_notification_state(
+    hass: HomeAssistant,
+    dkn_config_entry_factory: Callable[..., MockConfigEntry],
+    setup_api_class: type[FakeSetupAPI],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    hass = DummyHass()
-    entry = _make_entry()
-
-    monkeypatch.setattr(
-        integration.AirzoneAPI, "fetch_installations", AsyncMock(return_value=[])
-    )
-
-    await integration.async_setup_entry(hass, entry)
+    """Removed devices should clear notification state and dismiss banners."""
+    entry = dkn_config_entry_factory()
+    await _setup_entry(hass, entry, setup_api_class)
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
     listener = coordinator._listeners[-1]
 
-    integration.persistent_notification.async_create = Mock()
-    integration.persistent_notification.async_dismiss = Mock()
+    monkeypatch.setattr(integration.persistent_notification, "async_create", Mock())
+    monkeypatch.setattr(integration.persistent_notification, "async_dismiss", Mock())
 
     cancel = Mock()
     notify_state = hass.data[DOMAIN][entry.entry_id]["notify_state"]
@@ -629,21 +465,19 @@ async def test_removed_device_cleans_notification_state(
 
 @pytest.mark.asyncio
 async def test_removed_device_cleanup_runs_on_empty_data(
+    hass: HomeAssistant,
+    dkn_config_entry_factory: Callable[..., MockConfigEntry],
+    setup_api_class: type[FakeSetupAPI],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    hass = DummyHass()
-    entry = _make_entry()
-
-    monkeypatch.setattr(
-        integration.AirzoneAPI, "fetch_installations", AsyncMock(return_value=[])
-    )
-
-    await integration.async_setup_entry(hass, entry)
+    """Empty data should remove stale notify state, but None data should not."""
+    entry = dkn_config_entry_factory()
+    await _setup_entry(hass, entry, setup_api_class)
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
     listener = coordinator._listeners[-1]
 
-    integration.persistent_notification.async_create = Mock()
-    integration.persistent_notification.async_dismiss = Mock()
+    monkeypatch.setattr(integration.persistent_notification, "async_create", Mock())
+    monkeypatch.setattr(integration.persistent_notification, "async_dismiss", Mock())
 
     cancel_empty = Mock()
     notify_state = hass.data[DOMAIN][entry.entry_id]["notify_state"]
@@ -675,16 +509,13 @@ async def test_removed_device_cleanup_runs_on_empty_data(
 
 @pytest.mark.asyncio
 async def test_fallback_cache_clears_on_last_unload(
-    monkeypatch: pytest.MonkeyPatch,
+    hass: HomeAssistant,
+    dkn_config_entry_factory: Callable[..., MockConfigEntry],
+    setup_api_class: type[FakeSetupAPI],
 ) -> None:
-    hass = DummyHass()
-    entry = _make_entry()
-
-    monkeypatch.setattr(
-        integration.AirzoneAPI, "fetch_installations", AsyncMock(return_value=[])
-    )
-
-    await integration.async_setup_entry(hass, entry)
+    """Malformed-template warning cache should clear after the last unload."""
+    entry = dkn_config_entry_factory()
+    await _setup_entry(hass, entry, setup_api_class)
 
     integration._NOTIFY_FMT_FALLBACK_LOGGED.clear()
     strings = {
@@ -696,7 +527,8 @@ async def test_fallback_cache_clears_on_last_unload(
     integration._fmt(strings, "offline", "Living Room", "10:01", None, None)
     assert integration._NOTIFY_FMT_FALLBACK_LOGGED
 
-    unload_ok = await integration.async_unload_entry(hass, entry)
+    unload_ok = await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert unload_ok
     assert not integration._NOTIFY_FMT_FALLBACK_LOGGED
@@ -704,21 +536,19 @@ async def test_fallback_cache_clears_on_last_unload(
 
 @pytest.mark.asyncio
 async def test_offline_notification_includes_datetime_connection_date(
+    hass: HomeAssistant,
+    dkn_config_entry_factory: Callable[..., MockConfigEntry],
+    setup_api_class: type[FakeSetupAPI],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    hass = DummyHass()
-    entry = _make_entry()
-
-    monkeypatch.setattr(
-        integration.AirzoneAPI, "fetch_installations", AsyncMock(return_value=[])
-    )
-
-    await integration.async_setup_entry(hass, entry)
+    """Datetime connection_date values should be included in notification text."""
+    entry = dkn_config_entry_factory()
+    await _setup_entry(hass, entry, setup_api_class)
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
     listener = coordinator._listeners[-1]
 
-    integration.persistent_notification.async_create = Mock()
-    integration.persistent_notification.async_dismiss = Mock()
+    monkeypatch.setattr(integration.persistent_notification, "async_create", Mock())
+    monkeypatch.setattr(integration.persistent_notification, "async_dismiss", Mock())
 
     hass.data[DOMAIN][entry.entry_id]["notify_strings"] = {
         "offline": {
@@ -747,17 +577,43 @@ async def test_offline_notification_includes_datetime_connection_date(
 
 
 @pytest.mark.asyncio
-async def test_async_update_data_raises_on_initial_partial_installation_error(
-    monkeypatch: pytest.MonkeyPatch,
+async def test_async_update_data_uses_installation_id_over_relation_id(
+    hass: HomeAssistant,
+    dkn_config_entry_factory: Callable[..., MockConfigEntry],
 ) -> None:
-    hass = DummyHass()
-    entry = _make_entry()
+    """Coordinator refresh should use installation_id, not relation id."""
+    entry = dkn_config_entry_factory()
+    entry.add_to_hass(hass)
+    fetched: list[str] = []
+
+    class DummyAPI:
+        async def fetch_installations(self) -> list[dict[str, Any]]:
+            return [{"id": "relation-1", "installation_id": "install-1"}]
+
+        async def fetch_devices(self, inst_id: str) -> list[dict[str, Any]]:
+            fetched.append(inst_id)
+            return [{"id": "dev-a", "name": "Unit A", "scenary": "home"}]
+
+    data = await integration._async_update_data(hass, entry, DummyAPI())
+
+    assert fetched == ["install-1"]
+    assert set(data) == {"dev-a"}
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_raises_on_initial_partial_installation_error(
+    hass: HomeAssistant,
+    dkn_config_entry_factory: Callable[..., MockConfigEntry],
+) -> None:
+    """Initial partial installation errors should fail the coordinator refresh."""
+    entry = dkn_config_entry_factory()
+    entry.add_to_hass(hass)
 
     class DummyAPI:
         async def fetch_installations(self) -> list[dict[str, Any]]:
             return [
-                {"installation": {"id": "inst-a"}},
-                {"installation": {"id": "inst-b"}},
+                {"installation_id": "inst-a"},
+                {"installation_id": "inst-b"},
             ]
 
         async def fetch_devices(self, inst_id: str) -> list[dict[str, Any]]:
@@ -771,17 +627,16 @@ async def test_async_update_data_raises_on_initial_partial_installation_error(
 
 @pytest.mark.asyncio
 async def test_async_update_data_preserves_failed_installation_from_previous_snapshot(
-    monkeypatch: pytest.MonkeyPatch,
+    hass: HomeAssistant,
+    dkn_config_entry_factory: Callable[..., MockConfigEntry],
 ) -> None:
-    hass = DummyHass()
-    entry = _make_entry()
+    """Later partial errors should keep the last snapshot for failed installs."""
+    entry = dkn_config_entry_factory()
+    entry.add_to_hass(hass)
 
     class DummyAPIOk:
         async def fetch_installations(self) -> list[dict[str, Any]]:
-            return [
-                {"installation": {"id": "inst-a"}},
-                {"installation": {"id": "inst-b"}},
-            ]
+            return [{"installation_id": "inst-a"}, {"installation_id": "inst-b"}]
 
         async def fetch_devices(self, inst_id: str) -> list[dict[str, Any]]:
             if inst_id == "inst-a":
@@ -793,10 +648,7 @@ async def test_async_update_data_preserves_failed_installation_from_previous_sna
 
     class DummyAPIPartial:
         async def fetch_installations(self) -> list[dict[str, Any]]:
-            return [
-                {"installation": {"id": "inst-a"}},
-                {"installation": {"id": "inst-b"}},
-            ]
+            return [{"installation_id": "inst-a"}, {"installation_id": "inst-b"}]
 
         async def fetch_devices(self, inst_id: str) -> list[dict[str, Any]]:
             if inst_id == "inst-a":
@@ -812,14 +664,16 @@ async def test_async_update_data_preserves_failed_installation_from_previous_sna
 
 @pytest.mark.asyncio
 async def test_async_update_data_propagates_cancelled_fetch(
-    monkeypatch: pytest.MonkeyPatch,
+    hass: HomeAssistant,
+    dkn_config_entry_factory: Callable[..., MockConfigEntry],
 ) -> None:
-    hass = DummyHass()
-    entry = _make_entry()
+    """Cancelled per-installation fetches should propagate cancellation."""
+    entry = dkn_config_entry_factory()
+    entry.add_to_hass(hass)
 
     class DummyAPI:
         async def fetch_installations(self) -> list[dict[str, Any]]:
-            return [{"installation": {"id": "inst-cancel"}}]
+            return [{"installation_id": "inst-cancel"}]
 
         async def fetch_devices(self, _inst_id: str) -> list[dict[str, Any]]:
             raise asyncio.CancelledError()
@@ -830,67 +684,49 @@ async def test_async_update_data_propagates_cancelled_fetch(
 
 @pytest.mark.asyncio
 async def test_async_update_data_401_from_one_installation_triggers_reauth(
-    monkeypatch: pytest.MonkeyPatch,
+    hass: HomeAssistant,
+    dkn_config_entry_factory: Callable[..., MockConfigEntry],
 ) -> None:
-    hass = DummyHass()
-    entry = _make_entry()
-
-    flow_calls: list[dict[str, Any]] = []
-
-    async def _async_init(
-        domain: str, context: dict[str, Any], data: dict[str, Any]
-    ) -> dict[str, Any]:
-        flow_calls.append({"domain": domain, "context": context, "data": data})
-        return {"type": "flow"}
-
-    hass.config_entries.flow = types.SimpleNamespace(async_init=_async_init)
-    hass.async_create_task = lambda coro: asyncio.create_task(coro)
-
-    class FakeClientResponseError(Exception):
-        def __init__(self, status: int) -> None:
-            self.status = status
-
-    monkeypatch.setattr(integration, "ClientResponseError", FakeClientResponseError)
+    """A 401 from one installation should request reauth once."""
+    entry = dkn_config_entry_factory(data={CONF_USERNAME: "user@example.com"})
+    entry.add_to_hass(hass)
 
     class DummyAPI:
         async def fetch_installations(self) -> list[dict[str, Any]]:
             return [
-                {"installation": {"id": "inst-401"}},
-                {"installation": {"id": "inst-ok"}},
+                {"installation_id": "inst-401"},
+                {"installation_id": "inst-ok"},
             ]
 
         async def fetch_devices(self, inst_id: str) -> list[dict[str, Any]]:
             if inst_id == "inst-401":
-                raise FakeClientResponseError(401)
+                raise _client_response_error(401)
             return [{"id": "dev-ok", "name": "Unit OK", "scenary": "home"}]
 
     with pytest.raises(UpdateFailed, match=r"Authentication required \(401\)"):
         await integration._async_update_data(hass, entry, DummyAPI())
 
-    await asyncio.sleep(0)
+    await hass.async_block_till_done()
 
     bucket = hass.data[DOMAIN][entry.entry_id]
     assert bucket["reauth_requested"] is True
-    assert flow_calls and flow_calls[0]["domain"] == DOMAIN
 
 
 @pytest.mark.asyncio
 async def test_removed_cleanup_keeps_failed_installation_devices_only(
+    hass: HomeAssistant,
+    dkn_config_entry_factory: Callable[..., MockConfigEntry],
+    setup_api_class: type[FakeSetupAPI],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    hass = DummyHass()
-    entry = _make_entry()
-
-    monkeypatch.setattr(
-        integration.AirzoneAPI, "fetch_installations", AsyncMock(return_value=[])
-    )
-
-    await integration.async_setup_entry(hass, entry)
+    """Removed-device cleanup should spare devices from failed installations."""
+    entry = dkn_config_entry_factory()
+    await _setup_entry(hass, entry, setup_api_class)
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
     listener = coordinator._listeners[-1]
 
-    integration.persistent_notification.async_create = Mock()
-    integration.persistent_notification.async_dismiss = Mock()
+    monkeypatch.setattr(integration.persistent_notification, "async_create", Mock())
+    monkeypatch.setattr(integration.persistent_notification, "async_dismiss", Mock())
 
     bucket = hass.data[DOMAIN][entry.entry_id]
     bucket["last_update_had_install_errors"] = True
@@ -926,16 +762,17 @@ async def test_removed_cleanup_keeps_failed_installation_devices_only(
 
 
 @pytest.mark.asyncio
-async def test_async_update_data_prunes_removed_installation_cache_state() -> None:
-    hass = DummyHass()
-    entry = _make_entry()
+async def test_async_update_data_prunes_removed_installation_cache_state(
+    hass: HomeAssistant,
+    dkn_config_entry_factory: Callable[..., MockConfigEntry],
+) -> None:
+    """Removed installations should prune cached device/install mappings."""
+    entry = dkn_config_entry_factory(options={CONF_SCAN_INTERVAL: 10})
+    entry.add_to_hass(hass)
 
     class DummyAPIInitial:
         async def fetch_installations(self) -> list[dict[str, Any]]:
-            return [
-                {"installation": {"id": "inst-a"}},
-                {"installation": {"id": "inst-b"}},
-            ]
+            return [{"installation_id": "inst-a"}, {"installation_id": "inst-b"}]
 
         async def fetch_devices(self, inst_id: str) -> list[dict[str, Any]]:
             if inst_id == "inst-a":
@@ -946,7 +783,7 @@ async def test_async_update_data_prunes_removed_installation_cache_state() -> No
 
     class DummyAPIRemovedA:
         async def fetch_installations(self) -> list[dict[str, Any]]:
-            return [{"installation": {"id": "inst-b"}}]
+            return [{"installation_id": "inst-b"}]
 
         async def fetch_devices(self, _inst_id: str) -> list[dict[str, Any]]:
             return [{"id": "dev-b", "name": "Unit B2", "scenary": "home"}]

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -80,6 +80,17 @@ def _client_response_error(status: int) -> ClientResponseError:
     return ClientResponseError(request_info, history=(), status=status)
 
 
+def _latest_coordinator_listener(coordinator: Any) -> Callable[[], None]:
+    """Return the latest coordinator listener callback across HA internals."""
+    listeners = coordinator._listeners
+    if isinstance(listeners, dict):
+        listener = list(listeners.values())[-1]
+        if isinstance(listener, tuple):
+            return listener[0]
+        return listener
+    return listeners[-1]
+
+
 async def _setup_entry(
     hass: HomeAssistant,
     entry: MockConfigEntry,
@@ -191,7 +202,7 @@ async def test_offline_notification_after_debounce(
     entry = dkn_config_entry_factory()
     await _setup_entry(hass, entry, setup_api_class)
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
-    listener = coordinator._listeners[-1]
+    listener = _latest_coordinator_listener(coordinator)
 
     monkeypatch.setattr(integration.persistent_notification, "async_create", Mock())
     monkeypatch.setattr(integration.persistent_notification, "async_dismiss", Mock())
@@ -229,7 +240,7 @@ async def test_online_notification_dismisses_offline_and_schedules_banner(
     entry = dkn_config_entry_factory()
     await _setup_entry(hass, entry, setup_api_class)
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
-    listener = coordinator._listeners[-1]
+    listener = _latest_coordinator_listener(coordinator)
 
     monkeypatch.setattr(integration.persistent_notification, "async_create", Mock())
     monkeypatch.setattr(integration.persistent_notification, "async_dismiss", Mock())
@@ -298,7 +309,7 @@ async def test_listener_never_raises_on_unknown_placeholders(
     entry = dkn_config_entry_factory()
     await _setup_entry(hass, entry, setup_api_class)
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
-    listener = coordinator._listeners[-1]
+    listener = _latest_coordinator_listener(coordinator)
 
     monkeypatch.setattr(integration.persistent_notification, "async_create", Mock())
     monkeypatch.setattr(integration.persistent_notification, "async_dismiss", Mock())
@@ -336,7 +347,7 @@ async def test_online_banner_second_transition_cancels_previous(
     entry = dkn_config_entry_factory()
     await _setup_entry(hass, entry, setup_api_class)
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
-    listener = coordinator._listeners[-1]
+    listener = _latest_coordinator_listener(coordinator)
 
     monkeypatch.setattr(integration.persistent_notification, "async_create", Mock())
     monkeypatch.setattr(integration.persistent_notification, "async_dismiss", Mock())
@@ -399,7 +410,9 @@ async def test_online_to_offline_cancels_online_banner(
     """Going offline should cancel any pending online banner."""
     entry = dkn_config_entry_factory()
     await _setup_entry(hass, entry, setup_api_class)
-    listener = hass.data[DOMAIN][entry.entry_id]["coordinator"]._listeners[-1]
+    listener = _latest_coordinator_listener(
+        hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    )
 
     monkeypatch.setattr(integration.persistent_notification, "async_create", Mock())
     monkeypatch.setattr(integration.persistent_notification, "async_dismiss", Mock())
@@ -437,7 +450,7 @@ async def test_removed_device_cleans_notification_state(
     entry = dkn_config_entry_factory()
     await _setup_entry(hass, entry, setup_api_class)
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
-    listener = coordinator._listeners[-1]
+    listener = _latest_coordinator_listener(coordinator)
 
     monkeypatch.setattr(integration.persistent_notification, "async_create", Mock())
     monkeypatch.setattr(integration.persistent_notification, "async_dismiss", Mock())
@@ -474,7 +487,7 @@ async def test_removed_device_cleanup_runs_on_empty_data(
     entry = dkn_config_entry_factory()
     await _setup_entry(hass, entry, setup_api_class)
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
-    listener = coordinator._listeners[-1]
+    listener = _latest_coordinator_listener(coordinator)
 
     monkeypatch.setattr(integration.persistent_notification, "async_create", Mock())
     monkeypatch.setattr(integration.persistent_notification, "async_dismiss", Mock())
@@ -545,7 +558,7 @@ async def test_offline_notification_includes_datetime_connection_date(
     entry = dkn_config_entry_factory()
     await _setup_entry(hass, entry, setup_api_class)
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
-    listener = coordinator._listeners[-1]
+    listener = _latest_coordinator_listener(coordinator)
 
     monkeypatch.setattr(integration.persistent_notification, "async_create", Mock())
     monkeypatch.setattr(integration.persistent_notification, "async_dismiss", Mock())
@@ -723,7 +736,7 @@ async def test_removed_cleanup_keeps_failed_installation_devices_only(
     entry = dkn_config_entry_factory()
     await _setup_entry(hass, entry, setup_api_class)
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
-    listener = coordinator._listeners[-1]
+    listener = _latest_coordinator_listener(coordinator)
 
     monkeypatch.setattr(integration.persistent_notification, "async_create", Mock())
     monkeypatch.setattr(integration.persistent_notification, "async_dismiss", Mock())

--- a/tests/test_number_payload_shapes.py
+++ b/tests/test_number_payload_shapes.py
@@ -27,6 +27,16 @@ class DummyAPI:
         self.calls.append((device_id, payload))
 
 
+@pytest.fixture(autouse=True)
+def disable_post_write_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Avoid delayed refresh timers in payload-shape unit tests."""
+
+    monkeypatch.setattr(
+        "custom_components.airzoneclouddaikin.number.schedule_post_write_refresh",
+        lambda *_args, **_kwargs: None,
+    )
+
+
 def _make_entity(
     hass: HomeAssistant,
     dummy_coordinator_factory: Callable[[dict[str, dict[str, Any]], Any | None], Any],

--- a/tests/test_number_payload_shapes.py
+++ b/tests/test_number_payload_shapes.py
@@ -2,17 +2,18 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 import pytest
+from homeassistant.core import HomeAssistant
 
-
-class DummyCoordinator:
-    """Minimal coordinator stub exposing Airzone data and hass."""
-
-    def __init__(self, data: dict[str, dict[str, Any]], hass: Any) -> None:
-        self.data = data
-        self.hass = hass
+from custom_components.airzoneclouddaikin.const import DOMAIN
+from custom_components.airzoneclouddaikin.number import (
+    DKNSleepTimeNumber,
+    DKNUnoccupiedCoolMaxNumber,
+    DKNUnoccupiedHeatMinNumber,
+)
 
 
 class DummyAPI:
@@ -22,24 +23,24 @@ class DummyAPI:
         self.calls: list[tuple[str, dict[str, Any]]] = []
 
     async def put_device_fields(self, device_id: str, payload: dict[str, Any]) -> None:
+        """Record a device-field write."""
         self.calls.append((device_id, payload))
 
 
 def _make_entity(
+    hass: HomeAssistant,
+    dummy_coordinator_factory: Callable[[dict[str, dict[str, Any]], Any | None], Any],
     entity_cls: type[Any],
     *,
     device_data: dict[str, Any],
 ) -> tuple[Any, DummyAPI]:
+    """Instantiate a number entity with a fake coordinator and API."""
     entry_id = "entry"
     device_id = "dev1"
+    hass.data.setdefault(DOMAIN, {}).setdefault(entry_id, {})["optimistic"] = {}
 
-    hass = type("DummyHass", (), {"data": {}})()
-    hass.data.setdefault("airzoneclouddaikin", {}).setdefault(entry_id, {})[
-        "optimistic"
-    ] = {}
-
-    coordinator = DummyCoordinator({device_id: device_data}, hass)
     api = DummyAPI()
+    coordinator = dummy_coordinator_factory({device_id: device_data}, api)
 
     entity = entity_cls(
         coordinator=coordinator,
@@ -48,18 +49,22 @@ def _make_entity(
         device_id=device_id,
     )
     entity.hass = hass
+    entity.async_write_ha_state = lambda: None
 
     return entity, api
 
 
 @pytest.mark.asyncio
 async def test_sleep_time_payload_is_root_level(
-    load_number_module: Any,
+    hass: HomeAssistant,
+    dummy_coordinator_factory: Callable[[dict[str, dict[str, Any]], Any | None], Any],
 ) -> None:
     """Sleep time should send a root-level payload."""
-
     entity, api = _make_entity(
-        load_number_module.DKNSleepTimeNumber, device_data={"sleep_time": 30}
+        hass,
+        dummy_coordinator_factory,
+        DKNSleepTimeNumber,
+        device_data={"sleep_time": 30},
     )
 
     await entity.async_set_native_value(40)
@@ -69,12 +74,14 @@ async def test_sleep_time_payload_is_root_level(
 
 @pytest.mark.asyncio
 async def test_unoccupied_heat_min_payload_is_root_level(
-    load_number_module: Any,
+    hass: HomeAssistant,
+    dummy_coordinator_factory: Callable[[dict[str, dict[str, Any]], Any | None], Any],
 ) -> None:
     """Unoccupied heat min should send a root-level payload."""
-
     entity, api = _make_entity(
-        load_number_module.DKNUnoccupiedHeatMinNumber,
+        hass,
+        dummy_coordinator_factory,
+        DKNUnoccupiedHeatMinNumber,
         device_data={"min_temp_unoccupied": 16},
     )
 
@@ -85,12 +92,14 @@ async def test_unoccupied_heat_min_payload_is_root_level(
 
 @pytest.mark.asyncio
 async def test_unoccupied_cool_max_payload_is_root_level(
-    load_number_module: Any,
+    hass: HomeAssistant,
+    dummy_coordinator_factory: Callable[[dict[str, dict[str, Any]], Any | None], Any],
 ) -> None:
     """Unoccupied cool max should send a root-level payload."""
-
     entity, api = _make_entity(
-        load_number_module.DKNUnoccupiedCoolMaxNumber,
+        hass,
+        dummy_coordinator_factory,
+        DKNUnoccupiedCoolMaxNumber,
         device_data={"max_temp_unoccupied": 26},
     )
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2,288 +2,73 @@
 
 from __future__ import annotations
 
-import asyncio
-import importlib.util
-import sys
-import types
-from pathlib import Path
+from collections.abc import Callable
 from typing import Any
 
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.airzoneclouddaikin import sensor
+from custom_components.airzoneclouddaikin.config_flow import CONF_EXPOSE_PII
+from custom_components.airzoneclouddaikin.const import DOMAIN
 
 
-class DummyCoordinator:
-    def __init__(self, data: dict[str, dict[str, Any]]) -> None:
-        self.data = data
+async def test_async_setup_entry_removes_orphan_pii_entities_only(
+    hass: HomeAssistant,
+    dkn_config_entry_factory: Callable[..., MockConfigEntry],
+    dummy_coordinator_factory: Callable[[dict[str, dict[str, Any]], Any | None], Any],
+) -> None:
+    """Opt-out cleanup removes orphan PII sensors even with no device snapshot."""
+    entry = dkn_config_entry_factory(options={CONF_EXPOSE_PII: False})
+    entry.add_to_hass(hass)
+    coordinator = dummy_coordinator_factory({})
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {"coordinator": coordinator}
 
-
-class DummyRegistry:
-    def __init__(self, entities: list[Any]) -> None:
-        self.removed: list[str] = []
-        self.entities = entities
-
-    def async_remove(self, entity_id: str) -> None:
-        self.removed.append(entity_id)
-
-
-class DummyHass:
-    def __init__(
-        self, domain: str, coordinator: DummyCoordinator, entry_id: str
-    ) -> None:
-        self.data = {domain: {entry_id: {"coordinator": coordinator}}}
-
-
-class DummyEntry:
-    def __init__(self, entry_id: str) -> None:
-        self.entry_id = entry_id
-        self.options = {"expose_pii_identifiers": False}
-        self.data = {}
-
-
-class RegistryEntity:
-    def __init__(
-        self, entity_id: str, unique_id: str, domain: str, platform: str
-    ) -> None:
-        self.entity_id = entity_id
-        self.unique_id = unique_id
-        self.domain = domain
-        self.platform = platform
-
-
-def _load_sensor_module_with_stubs() -> tuple[Any, Any]:
-    stubbed_modules = [
-        "homeassistant",
-        "homeassistant.core",
-        "homeassistant.components",
-        "homeassistant.components.sensor",
-        "homeassistant.const",
-        "homeassistant.helpers",
-        "homeassistant.helpers.entity",
-        "homeassistant.helpers.update_coordinator",
-        "homeassistant.helpers.entity_registry",
-        "homeassistant.helpers.device_registry",
-        "homeassistant.helpers.event",
-        "homeassistant.util",
-        "homeassistant.util.dt",
-        "custom_components",
-        "custom_components.airzoneclouddaikin",
-        "custom_components.airzoneclouddaikin.__init__",
-        "custom_components.airzoneclouddaikin.sensor",
-    ]
-    original_modules = {name: sys.modules.get(name) for name in stubbed_modules}
-
-    try:
-        ha_module = sys.modules.setdefault(
-            "homeassistant", types.ModuleType("homeassistant")
-        )
-
-        core_module = sys.modules.setdefault(
-            "homeassistant.core", types.ModuleType("homeassistant.core")
-        )
-
-        class HomeAssistant:  # pragma: no cover - stub only
-            def __init__(self) -> None:
-                self.data: dict[str, Any] = {}
-
-        core_module.HomeAssistant = HomeAssistant
-
-        components_module = sys.modules.setdefault(
-            "homeassistant.components", types.ModuleType("homeassistant.components")
-        )
-
-        sensor_component = sys.modules.setdefault(
-            "homeassistant.components.sensor",
-            types.ModuleType("homeassistant.components.sensor"),
-        )
-
-        class SensorEntity:  # pragma: no cover - stub only
-            pass
-
-        class SensorDeviceClass:  # pragma: no cover - stub only
-            TEMPERATURE = "temperature"
-            TIMESTAMP = "timestamp"
-
-        class SensorStateClass:  # pragma: no cover - stub only
-            MEASUREMENT = "measurement"
-
-        sensor_component.SensorEntity = SensorEntity
-        sensor_component.SensorDeviceClass = SensorDeviceClass
-        sensor_component.SensorStateClass = SensorStateClass
-        components_module.sensor = sensor_component
-        ha_module.components = components_module
-
-        const_module = sys.modules.setdefault(
-            "homeassistant.const", types.ModuleType("homeassistant.const")
-        )
-        const_module.UnitOfTemperature = types.SimpleNamespace(CELSIUS="°C")
-        const_module.UnitOfTime = types.SimpleNamespace(MINUTES="min")
-
-        helpers_module = sys.modules.setdefault(
-            "homeassistant.helpers", types.ModuleType("homeassistant.helpers")
-        )
-
-        entity_module = sys.modules.setdefault(
-            "homeassistant.helpers.entity",
-            types.ModuleType("homeassistant.helpers.entity"),
-        )
-
-        class EntityCategory:  # pragma: no cover - stub only
-            DIAGNOSTIC = "diagnostic"
-
-        entity_module.EntityCategory = EntityCategory
-
-        update_module = sys.modules.setdefault(
-            "homeassistant.helpers.update_coordinator",
-            types.ModuleType("homeassistant.helpers.update_coordinator"),
-        )
-
-        class CoordinatorEntity:  # pragma: no cover - stub only
-            def __init__(self, coordinator: Any) -> None:
-                self.coordinator = coordinator
-
-            def __class_getitem__(cls, _item: Any) -> type:
-                return cls
-
-        class DataUpdateCoordinator:  # pragma: no cover - stub only
-            pass
-
-        update_module.CoordinatorEntity = CoordinatorEntity
-        update_module.DataUpdateCoordinator = DataUpdateCoordinator
-
-        registry_module = sys.modules.setdefault(
-            "homeassistant.helpers.entity_registry",
-            types.ModuleType("homeassistant.helpers.entity_registry"),
-        )
-
-        class DeviceInfo(dict):  # pragma: no cover - stub only
-            """Dict-backed DeviceInfo stub."""
-
-        device_registry_module = sys.modules.setdefault(
-            "homeassistant.helpers.device_registry",
-            types.ModuleType("homeassistant.helpers.device_registry"),
-        )
-        device_registry_module.CONNECTION_NETWORK_MAC = "mac"
-        device_registry_module.DeviceInfo = DeviceInfo
-
-        event_module = sys.modules.setdefault(
-            "homeassistant.helpers.event",
-            types.ModuleType("homeassistant.helpers.event"),
-        )
-
-        def async_call_later(*_args: Any, **_kwargs: Any) -> None:  # pragma: no cover
-            return None
-
-        event_module.async_call_later = async_call_later
-
-        util_module = sys.modules.setdefault(
-            "homeassistant.util", types.ModuleType("homeassistant.util")
-        )
-        dt_module = sys.modules.setdefault(
-            "homeassistant.util.dt", types.ModuleType("homeassistant.util.dt")
-        )
-
-        def _noop_parse_datetime(_value: Any) -> None:
-            return None
-
-        dt_module.parse_datetime = _noop_parse_datetime
-        dt_module.as_utc = lambda val: val
-        dt_module.get_default_time_zone = lambda: None
-        util_module.dt = dt_module
-
-        helpers_module.entity = entity_module
-        helpers_module.update_coordinator = update_module
-        helpers_module.entity_registry = registry_module
-        helpers_module.device_registry = device_registry_module
-        helpers_module.event = event_module
-        ha_module.helpers = helpers_module
-
-        custom_components_module = sys.modules.setdefault(
-            "custom_components", types.ModuleType("custom_components")
-        )
-        custom_components_module.__path__ = [str(ROOT / "custom_components")]
-
-        airzone_package = sys.modules.setdefault(
-            "custom_components.airzoneclouddaikin",
-            types.ModuleType("custom_components.airzoneclouddaikin"),
-        )
-        airzone_package.__path__ = [
-            str(ROOT / "custom_components" / "airzoneclouddaikin")
-        ]
-
-        airzone_init_stub = types.ModuleType(
-            "custom_components.airzoneclouddaikin.__init__"
-        )
-
-        class _AirzoneCoordinatorStub:
-            def __init__(self) -> None:
-                self.data: dict[str, dict[str, Any]] = {}
-
-        airzone_init_stub.AirzoneCoordinator = _AirzoneCoordinatorStub
-        sys.modules["custom_components.airzoneclouddaikin.__init__"] = airzone_init_stub
-
-        sensor_spec = importlib.util.spec_from_file_location(
-            "custom_components.airzoneclouddaikin.sensor",
-            ROOT / "custom_components" / "airzoneclouddaikin" / "sensor.py",
-        )
-        assert sensor_spec and sensor_spec.loader
-        sensor_module = importlib.util.module_from_spec(sensor_spec)
-        sys.modules[sensor_spec.name] = sensor_module
-        sensor_spec.loader.exec_module(sensor_module)
-
-        return sensor_module, registry_module
-    finally:
-        for name, original in original_modules.items():
-            if original is None:
-                sys.modules.pop(name, None)
-            else:
-                sys.modules[name] = original
-
-
-def test_async_setup_entry_removes_orphan_pii_entities_only() -> None:
-    """Opt-out cleanup removes orphan PII entities even if coordinator snapshot is empty."""
-
-    sensor_module, registry_module = _load_sensor_module_with_stubs()
-    domain = sensor_module.DOMAIN
-    entry_id = "entry-1"
-
-    coordinator = DummyCoordinator(data={})
-    hass = DummyHass(domain, coordinator, entry_id)
-    entry = DummyEntry(entry_id)
-
-    registry_entities = [
-        RegistryEntity("sensor.olddevice_mac", "olddevice_mac", "sensor", domain),
-        RegistryEntity(
-            "sensor.olddevice_installation_id",
-            "olddevice_installation_id",
-            "sensor",
-            domain,
-        ),
-        RegistryEntity(
-            "sensor.olddevice_local_temp", "olddevice_local_temp", "sensor", domain
-        ),
-        RegistryEntity("sensor.external_mac", "other_mac", "sensor", "other_platform"),
-        RegistryEntity(
-            "binary_sensor.olddevice_mac", "olddevice_mac", "binary_sensor", domain
-        ),
-    ]
-    reg = DummyRegistry(registry_entities)
-
-    registry_module.async_get = lambda _hass: reg
-    registry_module.async_entries_for_config_entry = (
-        lambda _reg, _entry_id: registry_entities
+    registry = er.async_get(hass)
+    pii_mac = registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "olddevice_mac",
+        suggested_object_id="olddevice_mac",
+        config_entry=entry,
+    )
+    pii_installation = registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "olddevice_installation_id",
+        suggested_object_id="olddevice_installation_id",
+        config_entry=entry,
+    )
+    non_pii = registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "olddevice_local_temp",
+        suggested_object_id="olddevice_local_temp",
+        config_entry=entry,
+    )
+    external = registry.async_get_or_create(
+        "sensor",
+        "other_platform",
+        "olddevice_mac",
+        suggested_object_id="external_mac",
+        config_entry=entry,
+    )
+    binary_sensor = registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        "olddevice_mac",
+        suggested_object_id="binary_olddevice_mac",
+        config_entry=entry,
     )
 
     added_entities: list[Any] = []
 
-    async def _run_setup() -> None:
-        await sensor_module.async_setup_entry(hass, entry, added_entities.extend)
+    await sensor.async_setup_entry(hass, entry, added_entities.extend)
 
-    asyncio.run(_run_setup())
-
-    assert reg.removed == [
-        "sensor.olddevice_mac",
-        "sensor.olddevice_installation_id",
-    ]
+    assert registry.async_get(pii_mac.entity_id) is None
+    assert registry.async_get(pii_installation.entity_id) is None
+    assert registry.async_get(non_pii.entity_id) is not None
+    assert registry.async_get(external.entity_id) is not None
+    assert registry.async_get(binary_sensor.entity_id) is not None
     assert added_entities == []

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -43,11 +43,21 @@ def _make_switch(
     return entity
 
 
+def _register_failing_climate_service(
+    hass: HomeAssistant, service: str, error: Exception
+) -> None:
+    """Register a real HA service that raises the requested error."""
+
+    async def failing_service_call(_call: Any) -> None:
+        raise error
+
+    hass.services.async_register("climate", service, failing_service_call)
+
+
 @pytest.mark.asyncio
 async def test_turn_on_timeout_keeps_proxy_and_calls_fallback(
     hass: HomeAssistant,
     dummy_coordinator_factory: Callable[[dict[str, dict[str, Any]], Any | None], Any],
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Timeouts in the climate proxy should not clear the cached entity id."""
     entity = _make_switch(
@@ -56,10 +66,7 @@ async def test_turn_on_timeout_keeps_proxy_and_calls_fallback(
         {"id": "dev1", "name": "Zone", "power": "0"},
     )
 
-    async def failing_call(*_args: Any, **_kwargs: Any) -> None:
-        raise TimeoutError("boom")
-
-    monkeypatch.setattr(hass.services, "async_call", failing_call)
+    _register_failing_climate_service(hass, "turn_on", TimeoutError("boom"))
     called = {"fallback": False}
 
     async def fake_fallback() -> None:
@@ -77,7 +84,6 @@ async def test_turn_on_timeout_keeps_proxy_and_calls_fallback(
 async def test_turn_on_service_not_found_drops_proxy(
     hass: HomeAssistant,
     dummy_coordinator_factory: Callable[[dict[str, dict[str, Any]], Any | None], Any],
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """ServiceNotFound must decouple the proxy and still call the fallback."""
     entity = _make_switch(
@@ -86,10 +92,9 @@ async def test_turn_on_service_not_found_drops_proxy(
         {"id": "dev1", "name": "Zone", "power": "0"},
     )
 
-    async def failing_call(*_args: Any, **_kwargs: Any) -> None:
-        raise ServiceNotFound("climate", "turn_on")
-
-    monkeypatch.setattr(hass.services, "async_call", failing_call)
+    _register_failing_climate_service(
+        hass, "turn_on", ServiceNotFound("climate", "turn_on")
+    )
     called = {"fallback": False}
 
     async def fake_fallback() -> None:
@@ -107,7 +112,6 @@ async def test_turn_on_service_not_found_drops_proxy(
 async def test_turn_on_homeassistant_error_keeps_proxy_and_calls_fallback(
     hass: HomeAssistant,
     dummy_coordinator_factory: Callable[[dict[str, dict[str, Any]], Any | None], Any],
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """HomeAssistantError in the climate proxy should not clear the cached id."""
     entity = _make_switch(
@@ -116,10 +120,9 @@ async def test_turn_on_homeassistant_error_keeps_proxy_and_calls_fallback(
         {"id": "dev1", "name": "Zone", "power": "0"},
     )
 
-    async def failing_call(*_args: Any, **_kwargs: Any) -> None:
-        raise HomeAssistantError("transient failure")
-
-    monkeypatch.setattr(hass.services, "async_call", failing_call)
+    _register_failing_climate_service(
+        hass, "turn_on", HomeAssistantError("transient failure")
+    )
     called = {"fallback": False}
 
     async def fake_fallback() -> None:
@@ -137,7 +140,6 @@ async def test_turn_on_homeassistant_error_keeps_proxy_and_calls_fallback(
 async def test_turn_off_unexpected_error_drops_proxy_and_calls_fallback(
     hass: HomeAssistant,
     dummy_coordinator_factory: Callable[[dict[str, dict[str, Any]], Any | None], Any],
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Unexpected exceptions in the climate proxy should drop the cached id."""
     entity = _make_switch(
@@ -146,10 +148,7 @@ async def test_turn_off_unexpected_error_drops_proxy_and_calls_fallback(
         {"id": "dev1", "name": "Zone", "power": "1"},
     )
 
-    async def failing_call(*_args: Any, **_kwargs: Any) -> None:
-        raise RuntimeError("unexpected boom")
-
-    monkeypatch.setattr(hass.services, "async_call", failing_call)
+    _register_failing_climate_service(hass, "turn_off", RuntimeError("unexpected boom"))
     called = {"fallback": False}
 
     async def fake_fallback() -> None:

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2,459 +2,209 @@
 
 from __future__ import annotations
 
-import asyncio
-import importlib.util
-import sys
-import types
-from pathlib import Path
+from collections.abc import Callable
 from typing import Any
 
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
-# --- Stub Home Assistant modules used by switch.py ---
-
-ha_module = sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
-
-core_module = sys.modules.setdefault(
-    "homeassistant.core", types.ModuleType("homeassistant.core")
-)
-
-
-class HomeAssistant:  # pragma: no cover - type stub only
-    """Minimal HomeAssistant stub for type hints."""
-
-    def __init__(self) -> None:
-        self.data: dict[str, Any] = {}
-        self.services: Any = types.SimpleNamespace()
-
-
-core_module.HomeAssistant = HomeAssistant
-
-# Exceptions module (needed before importing switch)
-exceptions_module = sys.modules.setdefault(
-    "homeassistant.exceptions", types.ModuleType("homeassistant.exceptions")
-)
-
-config_entries_module = sys.modules.setdefault(
-    "homeassistant.config_entries", types.ModuleType("homeassistant.config_entries")
-)
-
-if not hasattr(exceptions_module, "HomeAssistantError"):
-
-    class HomeAssistantError(Exception):
-        """Base Home Assistant error stub."""
-
-    exceptions_module.HomeAssistantError = HomeAssistantError
-
-if not hasattr(exceptions_module, "ServiceNotFound"):
-
-    class ServiceNotFound(exceptions_module.HomeAssistantError):  # type: ignore[misc]
-        """Raised when a service cannot be found."""
-
-    exceptions_module.ServiceNotFound = ServiceNotFound
-
-if not hasattr(config_entries_module, "ConfigEntry"):
-
-    class ConfigEntry:
-        """Minimal ConfigEntry stub."""
-
-        entry_id = "entry"
-
-    config_entries_module.ConfigEntry = ConfigEntry
-
-if not hasattr(config_entries_module, "SOURCE_REAUTH"):
-    config_entries_module.SOURCE_REAUTH = "reauth"
-
-# components.switch
-switch_component = sys.modules.setdefault(
-    "homeassistant.components.switch",
-    types.ModuleType("homeassistant.components.switch"),
-)
-
-if not hasattr(switch_component, "SwitchEntity"):
-
-    class SwitchEntity:  # pragma: no cover - base entity stub
-        async def async_write_ha_state(self) -> None:
-            return None
-
-    switch_component.SwitchEntity = SwitchEntity
-
-# helpers.entity_registry
-entity_registry_module = sys.modules.setdefault(
-    "homeassistant.helpers.entity_registry",
-    types.ModuleType("homeassistant.helpers.entity_registry"),
-)
-
-if not hasattr(entity_registry_module, "async_get"):
-
-    class DummyEntityRegistry:
-        def async_get_entity_id(
-            self, _domain: str, _platform: str, _unique_id: str
-        ) -> str | None:
-            return None
-
-    def async_get(_hass: Any) -> DummyEntityRegistry:
-        return DummyEntityRegistry()
-
-    entity_registry_module.async_get = async_get
-
-# helpers.device_registry
-device_registry_module = sys.modules.setdefault(
-    "homeassistant.helpers.device_registry",
-    types.ModuleType("homeassistant.helpers.device_registry"),
-)
-
-if not hasattr(device_registry_module, "DeviceInfo"):
-
-    class DeviceInfo(dict):  # pragma: no cover - minimal stub
-        """Dict-based DeviceInfo stub."""
-
-    device_registry_module.DeviceInfo = DeviceInfo
-    device_registry_module.CONNECTION_NETWORK_MAC = "mac"
-
-# helpers.update_coordinator
-helpers_module = sys.modules.setdefault(
-    "homeassistant.helpers", types.ModuleType("homeassistant.helpers")
-)
-
-helpers_update_module = sys.modules.setdefault(
-    "homeassistant.helpers.update_coordinator",
-    types.ModuleType("homeassistant.helpers.update_coordinator"),
-)
-
-if not hasattr(helpers_update_module, "CoordinatorEntity"):
-
-    class CoordinatorEntity:  # pragma: no cover - stub only
-        def __init__(self, coordinator: Any) -> None:
-            self.coordinator = coordinator
-
-        async def async_added_to_hass(self) -> None:  # type: ignore[empty-body]
-            return None
-
-        def __class_getitem__(cls, _item: Any) -> type:
-            return cls
-
-    helpers_update_module.CoordinatorEntity = CoordinatorEntity
-
-
-if not hasattr(helpers_update_module, "DataUpdateCoordinator"):
-
-    class DataUpdateCoordinator:  # pragma: no cover - stub only
-        def __init__(self, hass: HomeAssistant) -> None:
-            self.hass = hass
-
-    helpers_update_module.DataUpdateCoordinator = DataUpdateCoordinator
-
-helpers_module.update_coordinator = helpers_update_module
-
-# helpers.event (used indirectly by helpers.schedule_post_write_refresh)
-helpers_event_module = sys.modules.setdefault(
-    "homeassistant.helpers.event", types.ModuleType("homeassistant.helpers.event")
-)
-
-if not hasattr(helpers_event_module, "async_call_later"):
-
-    def async_call_later(*_args: Any, **_kwargs: Any) -> None:  # pragma: no cover
-        return None
-
-    helpers_event_module.async_call_later = async_call_later
-
-helpers_module.event = helpers_event_module
-
-# Wire top-level helpers module
-ha_module.helpers = helpers_module
-sys.modules.setdefault("homeassistant.helpers", helpers_module)
-sys.modules.setdefault("homeassistant.helpers.event", helpers_event_module)
-
-# aiohttp stub (needed by __init__ import chain)
-aiohttp_module = sys.modules.setdefault("aiohttp", types.ModuleType("aiohttp"))
-
-if not hasattr(aiohttp_module, "ClientResponseError"):
-
-    class ClientResponseError(Exception):
-        """Placeholder aiohttp.ClientResponseError stub."""
-
-    aiohttp_module.ClientResponseError = ClientResponseError
-
-# --- Package wiring for custom_components ---
-
-custom_components_module = sys.modules.setdefault(
-    "custom_components", types.ModuleType("custom_components")
-)
-custom_components_module.__path__ = [str(ROOT / "custom_components")]
-
-airzone_package = sys.modules.setdefault(
-    "custom_components.airzoneclouddaikin",
-    types.ModuleType("custom_components.airzoneclouddaikin"),
-)
-airzone_package.__path__ = [str(ROOT / "custom_components" / "airzoneclouddaikin")]
-
-airzone_init_stub = types.ModuleType("custom_components.airzoneclouddaikin.__init__")
-
-
-class _AirzoneCoordinatorStub:
-    """Lightweight AirzoneCoordinator replacement for switch imports."""
-
-    def __init__(self) -> None:
-        self.data: dict[str, dict[str, Any]] = {}
-        self.hass: HomeAssistant | None = None
-
-
-airzone_init_stub.AirzoneCoordinator = _AirzoneCoordinatorStub
-sys.modules["custom_components.airzoneclouddaikin.__init__"] = airzone_init_stub
-
-# --- Import the real switch implementation ---
-
-switch_spec = importlib.util.spec_from_file_location(
-    "custom_components.airzoneclouddaikin.switch",
-    ROOT / "custom_components" / "airzoneclouddaikin" / "switch.py",
-)
-assert switch_spec and switch_spec.loader
-switch_module_impl = importlib.util.module_from_spec(switch_spec)
-sys.modules[switch_spec.name] = switch_module_impl
-switch_spec.loader.exec_module(switch_module_impl)
-
-AirzonePowerSwitch = switch_module_impl.AirzonePowerSwitch
-DOMAIN = switch_module_impl.DOMAIN
-ServiceNotFound = exceptions_module.ServiceNotFound  # type: ignore[attr-defined]
-
-
-class DummyCoordinator:
-    """Minimal coordinator stub exposing Airzone data and hass."""
-
-    def __init__(self, data: dict[str, dict[str, Any]]) -> None:
-        self.data = data
-        self.hass: HomeAssistant | None = None
-
-
-class DummyHass(HomeAssistant):
-    """HomeAssistant stub with a controllable services layer."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.calls: list[tuple[str, str, dict[str, Any]]] = []
-
-        async def _async_call(
-            domain: str,
-            service: str,
-            service_data: dict[str, Any],
-            blocking: bool = False,
-            context: Any | None = None,
-        ) -> None:
-            self.calls.append((domain, service, service_data))
-            # Actual behavior (return / raise) is controlled per test
-            return None
-
-        self.services.async_call = _async_call  # type: ignore[assignment]
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceNotFound
+
+from custom_components.airzoneclouddaikin.const import DOMAIN
+from custom_components.airzoneclouddaikin.switch import AirzonePowerSwitch
 
 
 def _make_switch(
+    hass: HomeAssistant,
+    dummy_coordinator_factory: Callable[[dict[str, dict[str, Any]], Any | None], Any],
     device_snapshot: dict[str, Any],
     *,
     climate_entity_id: str = "climate.device",
-) -> tuple[AirzonePowerSwitch, DummyHass]:
-    """Helper to instantiate an AirzonePowerSwitch with stubs attached."""
-
+) -> AirzonePowerSwitch:
+    """Instantiate an AirzonePowerSwitch with a fake coordinator attached."""
     entry_id = "entry"
     device_id = device_snapshot.get("id", "device")
-
-    hass = DummyHass()
     hass.data.setdefault(DOMAIN, {}).setdefault(entry_id, {})["optimistic"] = {}
 
-    coordinator = DummyCoordinator({device_id: device_snapshot})
-    coordinator.hass = hass
-
+    coordinator = dummy_coordinator_factory({device_id: device_snapshot})
     entity = AirzonePowerSwitch(coordinator, entry_id, device_id)
     entity.hass = hass
-    entity.context = None  # type: ignore[assignment]
+    entity.context = None
+    entity.async_write_ha_state = lambda: None
     entity._climate_entity_id = climate_entity_id
 
-    # Avoid relying on the real entity registry in tests
     def _fake_resolve(self: AirzonePowerSwitch) -> str | None:
         return self._climate_entity_id
 
-    entity._resolve_climate_entity_id = _fake_resolve.__get__(  # type: ignore[assignment]
+    entity._resolve_climate_entity_id = _fake_resolve.__get__(
         entity,
         AirzonePowerSwitch,
     )
 
-    return entity, hass
+    return entity
 
 
-def test_turn_on_timeout_keeps_proxy_and_calls_fallback() -> None:
+@pytest.mark.asyncio
+async def test_turn_on_timeout_keeps_proxy_and_calls_fallback(
+    hass: HomeAssistant,
+    dummy_coordinator_factory: Callable[[dict[str, dict[str, Any]], Any | None], Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Timeouts in the climate proxy should not clear the cached entity id."""
+    entity = _make_switch(
+        hass,
+        dummy_coordinator_factory,
+        {"id": "dev1", "name": "Zone", "power": "0"},
+    )
 
-    device = {"id": "dev1", "name": "Zone", "power": "0"}
-    entity, hass = _make_switch(device)
-
-    async def failing_call(
-        domain: str,
-        service: str,
-        service_data: dict[str, Any],
-        blocking: bool = False,
-        context: Any | None = None,
-    ) -> None:
+    async def failing_call(*_args: Any, **_kwargs: Any) -> None:
         raise TimeoutError("boom")
 
-    hass.services.async_call = failing_call  # type: ignore[assignment]
+    monkeypatch.setattr(hass.services, "async_call", failing_call)
+    called = {"fallback": False}
 
-    called: dict[str, bool] = {"fallback": False}
-
-    async def fake_fallback(self: AirzonePowerSwitch) -> None:
+    async def fake_fallback() -> None:
         called["fallback"] = True
 
-    entity._fallback_turn_on = fake_fallback.__get__(  # type: ignore[assignment]
-        entity,
-        AirzonePowerSwitch,
-    )
+    entity._fallback_turn_on = fake_fallback
 
-    asyncio.run(entity.async_turn_on())
+    await entity.async_turn_on()
 
-    # Proxy should still be cached for next command
     assert entity._climate_entity_id == "climate.device"
-    # And we must have fallen back to direct P1 control
     assert called["fallback"] is True
 
 
-def test_turn_on_service_not_found_drops_proxy() -> None:
+@pytest.mark.asyncio
+async def test_turn_on_service_not_found_drops_proxy(
+    hass: HomeAssistant,
+    dummy_coordinator_factory: Callable[[dict[str, dict[str, Any]], Any | None], Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """ServiceNotFound must decouple the proxy and still call the fallback."""
-
-    device = {"id": "dev1", "name": "Zone", "power": "0"}
-    entity, hass = _make_switch(device)
-
-    async def failing_call(
-        domain: str,
-        service: str,
-        service_data: dict[str, Any],
-        blocking: bool = False,
-        context: Any | None = None,
-    ) -> None:
-        raise ServiceNotFound("service not found")
-
-    hass.services.async_call = failing_call  # type: ignore[assignment]
-
-    called: dict[str, bool] = {"fallback": False}
-
-    async def fake_fallback(self: AirzonePowerSwitch) -> None:
-        called["fallback"] = True
-
-    entity._fallback_turn_on = fake_fallback.__get__(  # type: ignore[assignment]
-        entity,
-        AirzonePowerSwitch,
+    entity = _make_switch(
+        hass,
+        dummy_coordinator_factory,
+        {"id": "dev1", "name": "Zone", "power": "0"},
     )
 
-    asyncio.run(entity.async_turn_on())
+    async def failing_call(*_args: Any, **_kwargs: Any) -> None:
+        raise ServiceNotFound("climate", "turn_on")
 
-    # ServiceNotFound should clear the cached climate proxy
+    monkeypatch.setattr(hass.services, "async_call", failing_call)
+    called = {"fallback": False}
+
+    async def fake_fallback() -> None:
+        called["fallback"] = True
+
+    entity._fallback_turn_on = fake_fallback
+
+    await entity.async_turn_on()
+
     assert entity._climate_entity_id is None
-    # Fallback must still be executed
     assert called["fallback"] is True
 
 
-def test_turn_on_homeassistant_error_keeps_proxy_and_calls_fallback() -> None:
-    """HomeAssistantError in the climate proxy should not clear the cached entity id."""
+@pytest.mark.asyncio
+async def test_turn_on_homeassistant_error_keeps_proxy_and_calls_fallback(
+    hass: HomeAssistant,
+    dummy_coordinator_factory: Callable[[dict[str, dict[str, Any]], Any | None], Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """HomeAssistantError in the climate proxy should not clear the cached id."""
+    entity = _make_switch(
+        hass,
+        dummy_coordinator_factory,
+        {"id": "dev1", "name": "Zone", "power": "0"},
+    )
 
-    device = {"id": "dev1", "name": "Zone", "power": "0"}
-    entity, hass = _make_switch(device)
-
-    from homeassistant.exceptions import HomeAssistantError
-
-    async def failing_call(
-        domain: str,
-        service: str,
-        service_data: dict[str, Any],
-        blocking: bool = False,
-        context: Any | None = None,
-    ) -> None:
+    async def failing_call(*_args: Any, **_kwargs: Any) -> None:
         raise HomeAssistantError("transient failure")
 
-    hass.services.async_call = failing_call  # type: ignore[assignment]
+    monkeypatch.setattr(hass.services, "async_call", failing_call)
+    called = {"fallback": False}
 
-    called: dict[str, bool] = {"fallback": False}
-
-    async def fake_fallback(self: AirzonePowerSwitch) -> None:
+    async def fake_fallback() -> None:
         called["fallback"] = True
 
-    entity._fallback_turn_on = fake_fallback.__get__(  # type: ignore[assignment]
-        entity,
-        AirzonePowerSwitch,
-    )
+    entity._fallback_turn_on = fake_fallback
 
-    asyncio.run(entity.async_turn_on())
+    await entity.async_turn_on()
 
     assert entity._climate_entity_id == "climate.device"
     assert called["fallback"] is True
 
 
-def test_turn_off_unexpected_error_drops_proxy_and_calls_fallback() -> None:
-    """Unexpected exceptions in the climate proxy should drop the cached entity id."""
-
-    device = {"id": "dev1", "name": "Zone", "power": "1"}
-    entity, hass = _make_switch(device)
-
-    async def failing_call(
-        domain: str,
-        service: str,
-        service_data: dict[str, Any],
-        blocking: bool = False,
-        context: Any | None = None,
-    ) -> None:
-        raise RuntimeError("unexpected boom")
-
-    hass.services.async_call = failing_call  # type: ignore[assignment]
-
-    called: dict[str, bool] = {"fallback": False}
-
-    async def fake_fallback(self: AirzonePowerSwitch) -> None:
-        called["fallback"] = True
-
-    entity._fallback_turn_off = fake_fallback.__get__(  # type: ignore[assignment]
-        entity,
-        AirzonePowerSwitch,
+@pytest.mark.asyncio
+async def test_turn_off_unexpected_error_drops_proxy_and_calls_fallback(
+    hass: HomeAssistant,
+    dummy_coordinator_factory: Callable[[dict[str, dict[str, Any]], Any | None], Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unexpected exceptions in the climate proxy should drop the cached id."""
+    entity = _make_switch(
+        hass,
+        dummy_coordinator_factory,
+        {"id": "dev1", "name": "Zone", "power": "1"},
     )
 
-    asyncio.run(entity.async_turn_off())
+    async def failing_call(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("unexpected boom")
+
+    monkeypatch.setattr(hass.services, "async_call", failing_call)
+    called = {"fallback": False}
+
+    async def fake_fallback() -> None:
+        called["fallback"] = True
+
+    entity._fallback_turn_off = fake_fallback
+
+    await entity.async_turn_off()
 
     assert entity._climate_entity_id is None
     assert called["fallback"] is True
 
 
-def test_send_event_logs_and_reraises_on_failure() -> None:
+@pytest.mark.asyncio
+async def test_send_event_logs_and_reraises_on_failure(
+    hass: HomeAssistant,
+    dummy_coordinator_factory: Callable[[dict[str, dict[str, Any]], Any | None], Any],
+) -> None:
     """_send_event should log and re-raise errors from the API client."""
-
-    device = {"id": "dev1", "name": "Zone", "power": "0"}
-    entity, _hass = _make_switch(device)
+    entity = _make_switch(
+        hass,
+        dummy_coordinator_factory,
+        {"id": "dev1", "name": "Zone", "power": "0"},
+    )
 
     class DummyAPI:
         async def send_event(self, _payload: dict[str, Any]) -> None:
             raise RuntimeError("P1 failed")
 
-    entity.coordinator.api = DummyAPI()  # type: ignore[attr-defined]
+    entity.coordinator.api = DummyAPI()
 
-    async def invoke() -> None:
+    with pytest.raises(RuntimeError, match="P1 failed"):
         await entity._send_event("P1", 1)
 
-    try:
-        asyncio.run(invoke())
-    except RuntimeError as err:
-        assert "P1 failed" in str(err)
-    else:  # pragma: no cover - safety net
-        raise AssertionError("_send_event did not re-raise API error")
 
-
-def test_backend_power_is_on_normalizes_values() -> None:
+def test_backend_power_is_on_normalizes_values(
+    hass: HomeAssistant,
+    dummy_coordinator_factory: Callable[[dict[str, dict[str, Any]], Any | None], Any],
+) -> None:
     """_backend_power_is_on should normalize common truthy/falsey values."""
     truthy_values = [True, "true", "on", "yes", 1, "1", 2, "2"]
     falsey_values = [False, "false", "off", "no", 0, "0", "", "none", None]
 
     for value in truthy_values:
-        device = {"id": "dev1", "name": "Zone", "power": value}
-        entity, _hass = _make_switch(device)
+        entity = _make_switch(
+            hass,
+            dummy_coordinator_factory,
+            {"id": "dev1", "name": "Zone", "power": value},
+        )
         assert entity._backend_power_is_on() is True
 
     for value in falsey_values:
-        device = {"id": "dev1", "name": "Zone", "power": value}
-        entity, _hass = _make_switch(device)
+        entity = _make_switch(
+            hass,
+            dummy_coordinator_factory,
+            {"id": "dev1", "name": "Zone", "power": value},
+        )
         assert entity._backend_power_is_on() is False

--- a/tests/test_test_hygiene.py
+++ b/tests/test_test_hygiene.py
@@ -1,0 +1,230 @@
+"""Guards for test isolation and secret hygiene."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TESTS_DIR = ROOT / "tests"
+
+BLOCKED_HELPERS = {
+    "force_module",
+    "stub_aiohttp_module",
+    "stub_config_entry_class",
+    "stub_custom_components_packages",
+    "stub_exceptions",
+    "stub_homeassistant_package",
+    "stub_update_coordinator_module",
+}
+
+BLOCKED_SECRET_MARKERS = (
+    "load_dotenv",
+    "dotenv",
+    "os.environ",
+    "os.getenv",
+    "environ.get",
+    "secrets" + "/.env",
+    "secrets" + "\\.env",
+)
+
+
+class ImportTimeStubVisitor(ast.NodeVisitor):
+    """Find import-time shared stubs that should be fixture scoped."""
+
+    def __init__(self) -> None:
+        self.scope_depth = 0
+        self.sys_aliases = {"sys"}
+        self.sys_modules_aliases: set[str] = set()
+        self.helper_aliases = set(BLOCKED_HELPERS)
+        self.violations: list[tuple[int, str]] = []
+
+    def visit_Import(self, node: ast.Import) -> None:
+        if self.scope_depth == 0:
+            for alias in node.names:
+                if alias.name == "sys":
+                    self.sys_aliases.add(alias.asname or alias.name)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        if self.scope_depth == 0:
+            for alias in node.names:
+                local_name = alias.asname or alias.name
+                if node.module == "sys" and alias.name == "modules":
+                    self.sys_modules_aliases.add(local_name)
+                if alias.name in BLOCKED_HELPERS:
+                    self.helper_aliases.add(local_name)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_decorators_and_defaults(node)
+        self._visit_nested(node.body)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_decorators_and_defaults(node)
+        self._visit_nested(node.body)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        self._visit_argument_defaults(node.args)
+        self.scope_depth += 1
+        self.visit(node.body)
+        self.scope_depth -= 1
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        if self.scope_depth == 0:
+            for target in node.targets:
+                self._check_assignment_target(target)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if self.scope_depth == 0:
+            self._check_assignment_target(node.target)
+        self.generic_visit(node)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        if self.scope_depth == 0:
+            self._check_assignment_target(node.target)
+        self.generic_visit(node)
+
+    def visit_Delete(self, node: ast.Delete) -> None:
+        if self.scope_depth == 0:
+            for target in node.targets:
+                self._check_delete_target(target)
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if self.scope_depth == 0:
+            if self._is_sys_modules_method_call(node):
+                self.violations.append(
+                    (node.lineno, "top-level sys.modules mutation call")
+                )
+            elif self._is_blocked_helper_call(node):
+                self.violations.append(
+                    (node.lineno, "top-level shared stub helper call")
+                )
+        self.generic_visit(node)
+
+    def _visit_decorators_and_defaults(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> None:
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        self._visit_argument_defaults(node.args)
+
+    def _visit_argument_defaults(self, arguments: ast.arguments) -> None:
+        for default in [*arguments.defaults, *arguments.kw_defaults]:
+            if default is not None:
+                self.visit(default)
+
+    def _visit_nested(self, body: list[ast.stmt]) -> None:
+        self.scope_depth += 1
+        for statement in body:
+            self.visit(statement)
+        self.scope_depth -= 1
+
+    def _check_assignment_target(self, target: ast.expr) -> None:
+        if isinstance(target, (ast.Tuple, ast.List)):
+            for element in target.elts:
+                self._check_assignment_target(element)
+            return
+        if isinstance(target, ast.Starred):
+            self._check_assignment_target(target.value)
+            return
+        if self._is_sys_modules(target):
+            self.violations.append(
+                (target.lineno, "top-level sys.modules reassignment")
+            )
+        elif isinstance(target, ast.Subscript) and self._is_sys_modules(target.value):
+            self.violations.append((target.lineno, "top-level sys.modules assignment"))
+
+    def _check_delete_target(self, target: ast.expr) -> None:
+        if isinstance(target, (ast.Tuple, ast.List)):
+            for element in target.elts:
+                self._check_delete_target(element)
+            return
+        if isinstance(target, ast.Starred):
+            self._check_delete_target(target.value)
+            return
+        if isinstance(target, ast.Subscript) and self._is_sys_modules(target.value):
+            self.violations.append((target.lineno, "top-level sys.modules deletion"))
+
+    def _is_sys_modules_method_call(self, node: ast.Call) -> bool:
+        return (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr in {"clear", "pop", "popitem", "setdefault", "update"}
+            and self._is_sys_modules(node.func.value)
+        )
+
+    def _is_blocked_helper_call(self, node: ast.Call) -> bool:
+        if isinstance(node.func, ast.Name):
+            return node.func.id in self.helper_aliases
+        if isinstance(node.func, ast.Attribute):
+            return node.func.attr in BLOCKED_HELPERS
+        return False
+
+    def _is_sys_modules(self, node: ast.expr) -> bool:
+        return (
+            isinstance(node, ast.Attribute)
+            and node.attr == "modules"
+            and isinstance(node.value, ast.Name)
+            and node.value.id in self.sys_aliases
+        ) or (isinstance(node, ast.Name) and node.id in self.sys_modules_aliases)
+
+
+def _scanned_test_paths() -> list[Path]:
+    paths = {
+        *TESTS_DIR.rglob("test_*.py"),
+        *TESTS_DIR.rglob("*_test.py"),
+        *TESTS_DIR.rglob("conftest.py"),
+        *TESTS_DIR.rglob("__init__.py"),
+    }
+    return sorted(path for path in paths if path.exists())
+
+
+def test_tests_do_not_install_shared_stubs_at_import_time() -> None:
+    """Keep shared Home Assistant stubs out of module import time."""
+    violations: list[str] = []
+
+    for path in _scanned_test_paths():
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+        visitor = ImportTimeStubVisitor()
+        visitor.visit(tree)
+        source_lines = source.splitlines()
+        for line_number, reason in visitor.violations:
+            offending_source = source_lines[line_number - 1].strip()
+            violations.append(
+                f"{path.relative_to(ROOT)}:{line_number}: {reason}: "
+                f"{offending_source}"
+            )
+
+    assert not violations, "\n".join(
+        [
+            "Shared test stubs must not be installed at module import time.",
+            "Move the operation into a fixture or test-local monkeypatch.",
+            *violations,
+        ]
+    )
+
+
+def test_ci_tests_do_not_reference_local_secrets() -> None:
+    """CI tests must not depend on local credential files or environment loaders."""
+    violations: list[str] = []
+
+    for path in _scanned_test_paths():
+        source = path.read_text(encoding="utf-8")
+        for line_number, line in enumerate(source.splitlines(), start=1):
+            if path.name == "test_test_hygiene.py":
+                continue
+            for marker in BLOCKED_SECRET_MARKERS:
+                if marker in line:
+                    violations.append(
+                        f"{path.relative_to(ROOT)}:{line_number}: "
+                        f"local secret/environment dependency: {line.strip()}"
+                    )
+
+    assert not violations, "\n".join(
+        [
+            "Tests collected by CI must use fake credentials only.",
+            "Keep manual credential checks outside tests/ and secrets/.env local-only.",
+            *violations,
+        ]
+    )

--- a/tests/test_test_hygiene.py
+++ b/tests/test_test_hygiene.py
@@ -87,6 +87,11 @@ class ImportTimeStubVisitor(ast.NodeVisitor):
             self._check_assignment_target(node.target)
         self.generic_visit(node)
 
+    def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
+        if self.scope_depth == 0:
+            self._track_sys_modules_alias(node.value, [node.target])
+        self.generic_visit(node)
+
     def visit_Delete(self, node: ast.Delete) -> None:
         if self.scope_depth == 0:
             for target in node.targets:
@@ -236,6 +241,27 @@ def test_import_time_stub_visitor_tracks_sys_modules_aliases() -> None:
             [
                 "import sys",
                 "mods = sys.modules",
+                "mods['fake_module'] = object()",
+                "mods.pop('other_module', None)",
+            ]
+        )
+    )
+    visitor = ImportTimeStubVisitor()
+    visitor.visit(tree)
+
+    assert visitor.violations == [
+        (3, "top-level sys.modules assignment"),
+        (4, "top-level sys.modules mutation call"),
+    ]
+
+
+def test_import_time_stub_visitor_tracks_namedexpr_sys_modules_aliases() -> None:
+    """Walrus aliases to sys.modules should not bypass import-time checks."""
+    tree = ast.parse(
+        "\n".join(
+            [
+                "import sys",
+                "(mods := sys.modules)",
                 "mods['fake_module'] = object()",
                 "mods.pop('other_module', None)",
             ]

--- a/tests/test_test_hygiene.py
+++ b/tests/test_test_hygiene.py
@@ -72,11 +72,14 @@ class ImportTimeStubVisitor(ast.NodeVisitor):
         if self.scope_depth == 0:
             for target in node.targets:
                 self._check_assignment_target(target)
+            self._track_sys_modules_alias(node.value, node.targets)
         self.generic_visit(node)
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
         if self.scope_depth == 0:
             self._check_assignment_target(node.target)
+            if node.value is not None:
+                self._track_sys_modules_alias(node.value, [node.target])
         self.generic_visit(node)
 
     def visit_AugAssign(self, node: ast.AugAssign) -> None:
@@ -146,6 +149,27 @@ class ImportTimeStubVisitor(ast.NodeVisitor):
         if isinstance(target, ast.Subscript) and self._is_sys_modules(target.value):
             self.violations.append((target.lineno, "top-level sys.modules deletion"))
 
+    def _track_sys_modules_alias(
+        self, value: ast.expr, targets: list[ast.expr]
+    ) -> None:
+        if not self._is_sys_modules(value):
+            return
+        for target in targets:
+            for name in self._iter_name_targets(target):
+                self.sys_modules_aliases.add(name)
+
+    def _iter_name_targets(self, target: ast.expr) -> list[str]:
+        if isinstance(target, ast.Name):
+            return [target.id]
+        if isinstance(target, (ast.Tuple, ast.List)):
+            names: list[str] = []
+            for element in target.elts:
+                names.extend(self._iter_name_targets(element))
+            return names
+        if isinstance(target, ast.Starred):
+            return self._iter_name_targets(target.value)
+        return []
+
     def _is_sys_modules_method_call(self, node: ast.Call) -> bool:
         return (
             isinstance(node.func, ast.Attribute)
@@ -203,6 +227,27 @@ def test_tests_do_not_install_shared_stubs_at_import_time() -> None:
             *violations,
         ]
     )
+
+
+def test_import_time_stub_visitor_tracks_sys_modules_aliases() -> None:
+    """Alias assignments to sys.modules should not bypass import-time checks."""
+    tree = ast.parse(
+        "\n".join(
+            [
+                "import sys",
+                "mods = sys.modules",
+                "mods['fake_module'] = object()",
+                "mods.pop('other_module', None)",
+            ]
+        )
+    )
+    visitor = ImportTimeStubVisitor()
+    visitor.visit(tree)
+
+    assert visitor.violations == [
+        (3, "top-level sys.modules assignment"),
+        (4, "top-level sys.modules mutation call"),
+    ]
 
 
 def test_ci_tests_do_not_reference_local_secrets() -> None:


### PR DESCRIPTION
## Summary
- Migrate the test dependency stack to `pytest-homeassistant-custom-component`, `pytest-asyncio`, and `aioresponses`.
- Replace import-time Home Assistant stubs with harness-style fixtures and fixture-scoped fakes.
- Preserve existing coverage for config flow, coordinator/setup/unload, API client, platforms, diagnostics, translations, and control payload contracts.
- Add test hygiene coverage to prevent global `sys.modules` stubs and CI dependencies on `secrets/.env`.

## Compatibility fixes surfaced by the new test harness
- Update reauth handling so the flow no longer assigns Home Assistant's read-only `_reauth_entry_id` property.
- Normalize diagnostics options with `dict(entry.options)` so immutable `mappingproxy` options from the HA test harness do not break diagnostics generation.

## Notes
- This PR is focused on test infrastructure migration plus the small HA-compatibility fixes required for the migrated harness.
- No unrelated runtime cleanup, dead-code removal, duplicate-code cleanup, or feature work is included here.
- Follow-up PRs will handle broader runtime cleanup and functional hardening separately.

## Validation
- `python -m ruff check .`
- `python -m black --check .`
- `python -m compileall -q custom_components tests`
- `python -m pytest -q`
- GitHub Actions: hassfest, lint, HACS, and tests are passing on the current PR head.

## Local pytest caveat
- Full `python -m pytest -q` may fail on native Windows before test collection because Home Assistant imports POSIX-only `fcntl` through `homeassistant.runner`.
- The full suite is expected to run in the Linux CI environment, where it is now passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reauthentication reliability by resolving and updating the correct config entry during reauth.
  * Improved diagnostics generation efficiency by avoiding deep copies while keeping the same redaction behavior.
* **Tests**
  * Migrated and refactored the test suite to a shared Home Assistant custom component pytest setup with consistent fixtures.
  * Expanded Airzone API, config flow, diagnostics, entity, and notification/coordinator coverage, plus added test hygiene to prevent stub misuse and secret leakage.
* **Chores**
  * Standardized pytest execution, updated pytest/pytest-asyncio/pythonpath settings, adjusted test dependency constraints, and refreshed workflow/test infrastructure notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->