### PR TITLE
Prepare 0.5.0 alpha changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## [0.5.0a1] - 2026-06-14
+## [0.5.0a1] - 2026-06-24
 ### Changed
 - **Breaking change:** Minimum Home Assistant version is now 2026.3.0.
 - **Breaking change:** Python runtime baseline is now 3.14+.
@@ -9,10 +9,22 @@
   and Home Assistant 2026.3.0+ minimum versions.
 - Dropped Python 3.13 from CI test matrix; tests now run on Python 3.14 only.
 - Bumped `homeassistant` minimum in `hacs.json` to `2026.3.0`.
-- Migrated test infrastructure to the Home Assistant custom component pytest stack.
+- Migrated test infrastructure to the Home Assistant custom component pytest
+  stack and strengthened coverage to 86 tests.
+- Refactored `build_device_info()` into a shared helper in `helpers.py` and
+  restored `DeviceInfo` type hints on `device_info` properties across all
+  platforms.
+- Use `device["id"]` as the stable Device Registry identifier, falling back to
+  the coordinator snapshot key when `id` is absent.
+- Cleaned up README badge, CI workflows, and local test harness.
+- Added CodeRabbit minimatch patterns to protect local Airzone secrets from
+  accidental review exposure.
 
 ### Added
 - Added `testpaths` and `asyncio_mode` config to `pyproject.toml`.
+- Added CodeRabbit repository configuration.
+- Added local secrets scaffold with secure manual testing documentation.
+- Added sanitized backend evidence tooling for safe diagnostics and review.
 
 ## [0.4.8] - 2026-03-03
 ### Changed

--- a/custom_components/airzoneclouddaikin/binary_sensor.py
+++ b/custom_components/airzoneclouddaikin/binary_sensor.py
@@ -19,13 +19,13 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
 from .__init__ import AirzoneCoordinator
-from .const import DOMAIN, INTERNAL_STALE_AFTER_SEC, MANUFACTURER
+from .const import DOMAIN, INTERNAL_STALE_AFTER_SEC
+from .helpers import build_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -97,20 +97,9 @@ class AirzoneDeviceOnBinarySensor(
         return bool(self._device)
 
     @property
-    def device_info(self) -> DeviceInfo:
-        """Return Device Registry metadata (connections via DeviceInfo)."""
-        dev = self._device
-        mac = (str(dev.get("mac") or "").strip()) or None
-        connections = {(CONNECTION_NETWORK_MAC, mac)} if mac else None
-
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._device_id)},
-            manufacturer=MANUFACTURER,
-            model=dev.get("brand") or "Airzone DKN",
-            sw_version=str(dev.get("firmware") or ""),
-            name=dev.get("name") or "Airzone Device",
-            connections=connections,
-        )
+    def device_info(self):
+        """Return Device Registry metadata."""
+        return build_device_info(self._device, self._device_id)
 
 
 class AirzoneWServerOnlineBinarySensor(
@@ -177,17 +166,6 @@ class AirzoneWServerOnlineBinarySensor(
         }
 
     @property
-    def device_info(self) -> DeviceInfo:
-        """Return Device Registry metadata (connections via DeviceInfo)."""
-        dev = self._device
-        mac = (str(dev.get("mac") or "").strip()) or None
-        connections = {(CONNECTION_NETWORK_MAC, mac)} if mac else None
-
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._device_id)},
-            manufacturer=MANUFACTURER,
-            model=dev.get("brand") or "Airzone DKN",
-            sw_version=str(dev.get("firmware") or ""),
-            name=dev.get("name") or "Airzone Device",
-            connections=connections,
-        )
+    def device_info(self):
+        """Return Device Registry metadata."""
+        return build_device_info(self._device, self._device_id)

--- a/custom_components/airzoneclouddaikin/binary_sensor.py
+++ b/custom_components/airzoneclouddaikin/binary_sensor.py
@@ -19,6 +19,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
@@ -97,7 +98,7 @@ class AirzoneDeviceOnBinarySensor(
         return bool(self._device)
 
     @property
-    def device_info(self):
+    def device_info(self) -> DeviceInfo:
         """Return Device Registry metadata."""
         return build_device_info(self._device, self._device_id)
 
@@ -166,6 +167,6 @@ class AirzoneWServerOnlineBinarySensor(
         }
 
     @property
-    def device_info(self):
+    def device_info(self) -> DeviceInfo:
         """Return Device Registry metadata."""
         return build_device_info(self._device, self._device_id)

--- a/custom_components/airzoneclouddaikin/climate.py
+++ b/custom_components/airzoneclouddaikin/climate.py
@@ -10,19 +10,18 @@ from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import ClimateEntityFeature, HVACMode
 from homeassistant.const import ATTR_TEMPERATURE, PRECISION_WHOLE, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .__init__ import AirzoneCoordinator
 from .const import (
     CONF_ENABLE_HEAT_COOL,
     DOMAIN,
-    MANUFACTURER,
 )
 from .helpers import (
     acquire_device_lock,
     async_auto_exit_sleep_if_needed,
     bitmask_supports_p2,
+    build_device_info,
     clamp_temperature,
     optimistic_get,
     optimistic_invalidate,
@@ -220,24 +219,9 @@ class AirzoneClimate(CoordinatorEntity[AirzoneCoordinator], ClimateEntity):
     # ---- Device info -----------------------------------------------------
 
     @property
-    def device_info(self) -> DeviceInfo:
-        """Return rich device metadata for the device registry.
-
-        NOTE: We pass the MAC through the constructor 'connections' using
-        CONNECTION_NETWORK_MAC and avoid mutating the object after creation.
-        """
-        dev = self._device
-        mac = (str(dev.get("mac") or "").strip()) or None
-        connections = {(CONNECTION_NETWORK_MAC, mac)} if mac else None
-
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._device_id)},
-            manufacturer=MANUFACTURER,
-            model=dev.get("brand") or "Airzone DKN",
-            sw_version=str(dev.get("firmware") or ""),
-            name=dev.get("name") or "Airzone Device",
-            connections=connections,
-        )
+    def device_info(self):
+        """Return rich device metadata for the device registry."""
+        return build_device_info(self._device, self._device_id)
 
     # ---- Core state ------------------------------------------------------
 

--- a/custom_components/airzoneclouddaikin/climate.py
+++ b/custom_components/airzoneclouddaikin/climate.py
@@ -10,6 +10,7 @@ from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import ClimateEntityFeature, HVACMode
 from homeassistant.const import ATTR_TEMPERATURE, PRECISION_WHOLE, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .__init__ import AirzoneCoordinator
@@ -219,7 +220,7 @@ class AirzoneClimate(CoordinatorEntity[AirzoneCoordinator], ClimateEntity):
     # ---- Device info -----------------------------------------------------
 
     @property
-    def device_info(self):
+    def device_info(self) -> DeviceInfo:
         """Return rich device metadata for the device registry."""
         return build_device_info(self._device, self._device_id)
 

--- a/custom_components/airzoneclouddaikin/helpers.py
+++ b/custom_components/airzoneclouddaikin/helpers.py
@@ -361,11 +361,12 @@ async def async_auto_exit_sleep_if_needed(
 
 def build_device_info(device: dict[str, Any], device_id: str) -> DeviceInfo:
     """Return DeviceInfo with identifiers, manufacturer, model, sw_version, name, and MAC connection."""
+    stable_device_id = str(device.get("id") or device_id).strip() or device_id
     mac = (str(device.get("mac") or "").strip()) or None
     connections = {(CONNECTION_NETWORK_MAC, mac)} if mac else None
 
     return DeviceInfo(
-        identifiers={(DOMAIN, device_id)},
+        identifiers={(DOMAIN, stable_device_id)},
         manufacturer=MANUFACTURER,
         model=device.get("brand") or "Airzone DKN",
         sw_version=str(device.get("firmware") or ""),

--- a/custom_components/airzoneclouddaikin/helpers.py
+++ b/custom_components/airzoneclouddaikin/helpers.py
@@ -24,11 +24,13 @@ from collections.abc import Awaitable, Callable, Mapping
 from typing import Any
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
     DOMAIN,
+    MANUFACTURER,
     OPTIMISTIC_TTL_SEC,
     POST_WRITE_REFRESH_DELAY_SEC,
     SCENARY_HOME,
@@ -355,3 +357,18 @@ async def async_auto_exit_sleep_if_needed(
             on_success()
 
     schedule_post_write_refresh(hass, coordinator, entry_id=entry_id)
+
+
+def build_device_info(device: dict[str, Any], device_id: str) -> DeviceInfo:
+    """Return DeviceInfo with identifiers, manufacturer, model, sw_version, name, and MAC connection."""
+    mac = (str(device.get("mac") or "").strip()) or None
+    connections = {(CONNECTION_NETWORK_MAC, mac)} if mac else None
+
+    return DeviceInfo(
+        identifiers={(DOMAIN, device_id)},
+        manufacturer=MANUFACTURER,
+        model=device.get("brand") or "Airzone DKN",
+        sw_version=str(device.get("firmware") or ""),
+        name=device.get("name") or "Airzone Device",
+        connections=connections,
+    )

--- a/custom_components/airzoneclouddaikin/number.py
+++ b/custom_components/airzoneclouddaikin/number.py
@@ -9,15 +9,15 @@ from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature, UnitOfTime
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .__init__ import AirzoneCoordinator
 from .airzone_api import AirzoneAPI
-from .const import DOMAIN, MANUFACTURER
+from .const import DOMAIN
 from .helpers import (
     acquire_device_lock,
+    build_device_info,
     clamp_number,
     optimistic_get,
     optimistic_set,
@@ -125,24 +125,9 @@ class _BaseDKNNumber(CoordinatorEntity[AirzoneCoordinator], NumberEntity):
 
     # ---------- Device registry ----------
     @property
-    def device_info(self) -> DeviceInfo:
-        """Return device registry info (PII-safe and unified across platforms).
-
-        NOTE: Pass MAC via 'connections' at construction time using
-        CONNECTION_NETWORK_MAC; avoid mutating the object after creation.
-        """
-        device = self._device
-        mac = (str(device.get("mac") or "").strip()) or None
-        connections = {(CONNECTION_NETWORK_MAC, mac)} if mac else None
-
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._device_id)},
-            manufacturer=MANUFACTURER,
-            model=device.get("brand") or "Airzone DKN",
-            sw_version=str(device.get("firmware") or ""),
-            name=device.get("name") or "Airzone Device",
-            connections=connections,
-        )
+    def device_info(self):
+        """Return device registry info (PII-safe and unified across platforms)."""
+        return build_device_info(self._device, self._device_id)
 
     # ---------- State ----------
     @property

--- a/custom_components/airzoneclouddaikin/number.py
+++ b/custom_components/airzoneclouddaikin/number.py
@@ -9,6 +9,7 @@ from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature, UnitOfTime
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -125,7 +126,7 @@ class _BaseDKNNumber(CoordinatorEntity[AirzoneCoordinator], NumberEntity):
 
     # ---------- Device registry ----------
     @property
-    def device_info(self):
+    def device_info(self) -> DeviceInfo:
         """Return device registry info (PII-safe and unified across platforms)."""
         return build_device_info(self._device, self._device_id)
 

--- a/custom_components/airzoneclouddaikin/sensor.py
+++ b/custom_components/airzoneclouddaikin/sensor.py
@@ -23,14 +23,13 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import UnitOfTemperature, UnitOfTime
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
 from .__init__ import AirzoneCoordinator
-from .const import DOMAIN, MANUFACTURER
-from .helpers import device_supports_heat_cool
+from .const import DOMAIN
+from .helpers import build_device_info, device_supports_heat_cool
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -356,24 +355,9 @@ class AirzoneSensor(CoordinatorEntity[AirzoneCoordinator], SensorEntity):
         self._attr_entity_registry_enabled_default = enabled_by_default
 
     @property
-    def device_info(self) -> DeviceInfo:
-        """Return unified Device Registry metadata.
-
-        NOTE: We pass the MAC through the constructor 'connections' using
-        CONNECTION_NETWORK_MAC and avoid mutating the object after creation.
-        """
-        dev = self._device
-        mac = (str(dev.get("mac") or "").strip()) or None
-        connections = {(CONNECTION_NETWORK_MAC, mac)} if mac else None
-
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._device_id)},
-            manufacturer=MANUFACTURER,
-            model=dev.get("brand") or "Airzone DKN",
-            sw_version=str(dev.get("firmware") or ""),
-            name=dev.get("name") or "Airzone Device",
-            connections=connections,
-        )
+    def device_info(self):
+        """Return unified Device Registry metadata."""
+        return build_device_info(self._device, self._device_id)
 
     @property
     def _device(self) -> dict[str, Any]:

--- a/custom_components/airzoneclouddaikin/sensor.py
+++ b/custom_components/airzoneclouddaikin/sensor.py
@@ -23,6 +23,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import UnitOfTemperature, UnitOfTime
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
@@ -355,7 +356,7 @@ class AirzoneSensor(CoordinatorEntity[AirzoneCoordinator], SensorEntity):
         self._attr_entity_registry_enabled_default = enabled_by_default
 
     @property
-    def device_info(self):
+    def device_info(self) -> DeviceInfo:
         """Return unified Device Registry metadata."""
         return build_device_info(self._device, self._device_id)
 

--- a/custom_components/airzoneclouddaikin/switch.py
+++ b/custom_components/airzoneclouddaikin/switch.py
@@ -10,14 +10,14 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceNotFound
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .__init__ import AirzoneCoordinator  # typed coordinator
-from .const import DOMAIN, MANUFACTURER
+from .const import DOMAIN
 from .helpers import (
     acquire_device_lock,
     async_auto_exit_sleep_if_needed,
+    build_device_info,
     optimistic_get,
     optimistic_invalidate,
     optimistic_set,
@@ -194,24 +194,9 @@ class AirzonePowerSwitch(CoordinatorEntity[AirzoneCoordinator], SwitchEntity):
         return "mdi:power" if self.is_on else "mdi:power-off"
 
     @property
-    def device_info(self) -> DeviceInfo:
-        """Return device registry info (PII-safe and unified across platforms).
-
-        NOTE: Pass MAC via 'connections' at construction time using
-        CONNECTION_NETWORK_MAC; avoid mutating the object after creation.
-        """
-        dev = self._device
-        mac = (str(dev.get("mac") or "").strip()) or None
-        connections = {(CONNECTION_NETWORK_MAC, mac)} if mac else None
-
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._device_id)},
-            manufacturer=MANUFACTURER,
-            model=dev.get("brand") or "Airzone DKN",
-            sw_version=str(dev.get("firmware") or ""),
-            name=dev.get("name") or "Airzone Device",
-            connections=connections,
-        )
+    def device_info(self):
+        """Return device registry info (PII-safe and unified across platforms)."""
+        return build_device_info(self._device, self._device_id)
 
     # -----------------------------
     # Write operations

--- a/custom_components/airzoneclouddaikin/switch.py
+++ b/custom_components/airzoneclouddaikin/switch.py
@@ -10,6 +10,7 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceNotFound
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .__init__ import AirzoneCoordinator  # typed coordinator
@@ -194,7 +195,7 @@ class AirzonePowerSwitch(CoordinatorEntity[AirzoneCoordinator], SwitchEntity):
         return "mdi:power" if self.is_on else "mdi:power-off"
 
     @property
-    def device_info(self):
+    def device_info(self) -> DeviceInfo:
         """Return device registry info (PII-safe and unified across platforms)."""
         return build_device_info(self._device, self._device_id)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -12,6 +12,7 @@ from custom_components.airzoneclouddaikin import helpers
 from custom_components.airzoneclouddaikin.const import DOMAIN
 from custom_components.airzoneclouddaikin.helpers import (
     async_auto_exit_sleep_if_needed,
+    build_device_info,
     optimistic_get,
     optimistic_invalidate,
     optimistic_set,
@@ -169,3 +170,24 @@ async def test_auto_exit_sleep_skips_active_session(
     assert device_id not in optimistic_bucket
     assert "pending_refresh" not in hass.data.get(DOMAIN, {}).get(entry_id, {})
     assert not scheduled
+
+
+def test_build_device_info_uses_snapshot_id_when_present() -> None:
+    """Identifiers should use device["id"] when available, not the coordinator key."""
+    device = {"id": "snap-1", "name": "Room", "mac": "AA:BB:CC:DD:EE:01"}
+    info = build_device_info(device, "coordinator-key-mac")
+
+    identifiers = info.get("identifiers")
+    assert identifiers is not None
+    assert ("airzoneclouddaikin", "snap-1") in identifiers
+    assert ("airzoneclouddaikin", "coordinator-key-mac") not in identifiers
+
+
+def test_build_device_info_falls_back_to_device_id() -> None:
+    """When device["id"] is missing, identifiers must fall back to the coordinator key."""
+    device: dict[str, str] = {"name": "Room", "mac": "AA:BB:CC:DD:EE:02"}
+    info = build_device_info(device, "fallback-key")
+
+    identifiers = info.get("identifiers")
+    assert identifiers is not None
+    assert ("airzoneclouddaikin", "fallback-key") in identifiers


### PR DESCRIPTION
## Target version

**`0.5.0a1`** — kept unchanged (no `v0.5.0a1` tag or release exists yet).

## Summary of changes

- Updated the `[0.5.0a1]` changelog entry to capture all accumulated work in this alpha cycle:
  - CodeRabbit repository configuration
  - Local secrets scaffold with secure manual testing documentation
  - Sanitized backend evidence tooling for safe diagnostics and review
  - Test infrastructure migrated to Home Assistant custom component pytest stack, coverage strengthened to **86 tests**
  - `build_device_info()` refactored into a shared helper in `helpers.py` with `DeviceInfo` type hints restored across all platforms
  - `device["id"]` used as the stable Device Registry identifier, with fallback to the coordinator snapshot key
  - README badge, CI workflows, and local test harness cleanup
  - CodeRabbit minimatch patterns to protect local Airzone secrets from accidental review exposure

## Validations

- `ruff check --fix --select I && ruff check` — All checks passed
- `black --check .` — 25 files would be left unchanged
- `pytest -q` — 86 passed, 0 failed
- `compileall -q custom_components tests scripts` — clean