### PR TITLE
Prepare 0.5.0 alpha changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Refactored `build_device_info()` into a shared helper in `helpers.py` and
   restored `DeviceInfo` type hints on `device_info` properties across all
   platforms.
-- Use `device["id"]` as the stable Device Registry identifier, falling back to
+- Used `device["id"]` as the stable Device Registry identifier, falling back to
   the coordinator snapshot key when `id` is absent.
 - Cleaned up README badge, CI workflows, and local test harness.
 - Added CodeRabbit minimatch patterns to protect local Airzone secrets from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## [0.5.0a1] - 2026-06-14
+## [0.5.0a1] - 2026-06-24
 ### Changed
 - **Breaking change:** Minimum Home Assistant version is now 2026.3.0.
 - **Breaking change:** Python runtime baseline is now 3.14+.
@@ -9,10 +9,22 @@
   and Home Assistant 2026.3.0+ minimum versions.
 - Dropped Python 3.13 from CI test matrix; tests now run on Python 3.14 only.
 - Bumped `homeassistant` minimum in `hacs.json` to `2026.3.0`.
-- Migrated test infrastructure to the Home Assistant custom component pytest stack.
+- Migrated test infrastructure to the Home Assistant custom component pytest
+  stack and strengthened coverage to 86 tests.
+- Refactored `build_device_info()` into a shared helper in `helpers.py` and
+  restored `DeviceInfo` type hints on `device_info` properties across all
+  platforms.
+- Use `device["id"]` as the stable Device Registry identifier, falling back to
+  the coordinator snapshot key when `id` is absent.
+- Cleaned up README badge, CI workflows, and local test harness.
+- Added CodeRabbit minimatch patterns to protect local Airzone secrets from
+  accidental review exposure.
 
 ### Added
 - Added `testpaths` and `asyncio_mode` config to `pyproject.toml`.
+- Added CodeRabbit repository configuration.
+- Added local secrets scaffold with secure manual testing documentation.
+- Added sanitized backend evidence tooling for safe diagnostics and review.
 
 ## [0.4.8] - 2026-03-03
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
+
 ## [0.5.0a1] - 2026-06-24
+
 ### Changed
 - **Breaking change:** Minimum Home Assistant version is now 2026.3.0.
 - **Breaking change:** Python runtime baseline is now 3.14+.
@@ -27,6 +29,7 @@
 - Added sanitized backend evidence tooling for safe diagnostics and review.
 
 ## [0.4.8] - 2026-03-03
+
 ### Changed
 - Enable HACS `zip_release` packaging and add validated release ZIP workflows for
   `airzoneclouddaikin.zip`.


### PR DESCRIPTION
## Target version

**`0.5.0a1`** — kept unchanged (no `v0.5.0a1` tag or release exists yet).

## Summary of changes

- Updated the `[0.5.0a1]` changelog entry to capture all accumulated work in this alpha cycle:
  - CodeRabbit repository configuration
  - Local secrets scaffold with secure manual testing documentation
  - Sanitized backend evidence tooling for safe diagnostics and review
  - Test infrastructure migrated to Home Assistant custom component pytest stack, coverage strengthened to **86 tests**
  - `build_device_info()` refactored into a shared helper in `helpers.py` with `DeviceInfo` type hints restored across all platforms
  - `device["id"]` used as the stable Device Registry identifier, with fallback to the coordinator snapshot key
  - README badge, CI workflows, and local test harness cleanup
  - CodeRabbit minimatch patterns to protect local Airzone secrets from accidental review exposure

## Validations

- `ruff check --fix --select I && ruff check` — all checks passed
- `black --check .` — 25 files unchanged
- `pytest -q` — 86 passed, 0 failed
- `compileall -q custom_components tests scripts` — clean

## Diff scope

- **1 commit**, **1 file**: `CHANGELOG.md` only
- No changes to `custom_components/`, `tests/`, `.github/`, or `README`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the release date for the upcoming alpha release.
  * Expanded the changelog with recent improvements across testing, device handling, and developer workflow.

* **Bug Fixes**
  * Improved device identifier consistency and shared device information handling.

* **Chores**
  * Added cleanup and safeguards for local secrets, repository configuration, and backend evidence tooling.
  * Included additional notes on testing coverage and documentation/CI maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->