### PR TITLE
Harden release and package workflows

### DIFF
--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   package:
     runs-on: ubuntu-latest

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -1,6 +1,10 @@
 name: Package Test
 
 on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -12,6 +16,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Python 3.14
         uses: actions/setup-python@v6
@@ -49,7 +55,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          pytest -q
+          python -m pytest -q
         env:
           PYTHONPATH: .
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
 
       - name: Set up Python 3.14
         uses: actions/setup-python@v6
@@ -51,7 +54,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          pytest -q
+          python -m pytest -q
         env:
           PYTHONPATH: .
 


### PR DESCRIPTION
## Summary

- Disable persisted checkout credentials in the release workflow.
- Explicitly checkout the release tag when publishing release assets.
- Run package validation automatically on PRs and pushes to `main`.
- Use `python -m pytest -q` in release/package workflows to ensure pytest runs under the selected Python interpreter.

## Safety

- CI-only change.
- No integration code changed.
- No tests changed.
- No translations changed.
- No version or release metadata changed.
- ZIP filename and ZIP structure validation unchanged.

## Validation

```bash
ruff check .
black --check .
python -m pytest -q
```

Workflow YAML parsing was also run if available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated test and release workflows to run more reliably.
  * Improved checkout behavior in CI and release jobs for safer execution.
  * Adjusted test invocation in the package test pipeline to use a more consistent Python command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->