### PR TITLE
Prepare 0.5.0a2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,17 @@
 
 ### Changed
 - Refactored duplicated float parsing into the shared `parse_float()` helper.
-- Reused `parse_float()` across climate and sensor entities while preserving existing rounding behavior: climate temperatures remain unrounded, sensor temperatures stay at 1 decimal, and coordinates stay at 6 decimals.
-- Migrated HTTP API tests from `aioresponses` to `aiointercept` so the test stack remains compatible with newer `aiohttp` versions.
-- Kept `pytest-homeassistant-custom-component>=0.13.340` as an open lower bound for test coverage against newer Home Assistant pytest stacks.
+- Reused `parse_float()` across climate and sensor entities while preserving
+  existing rounding behavior: climate temperatures remain unrounded, sensor
+  temperatures stay at 1 decimal, and coordinates stay at 6 decimals.
+- Migrated HTTP API tests from `aioresponses` to `aiointercept` so the test stack
+  remains compatible with newer `aiohttp` versions.
+- Kept `pytest-homeassistant-custom-component>=0.13.340` as an open lower bound
+  for test coverage against newer Home Assistant pytest stacks.
 
 ### Added
-- Added unit coverage for comma and dot decimal parsing, invalid values, optional precision, `TypeError` handling, and unparseable collections.
+- Added unit coverage for comma and dot decimal parsing, invalid values, optional
+  precision, `TypeError` handling, and unparseable collections.
 
 ## [0.5.0a1] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.5.0a2] - 2026-06-27
+
+### Changed
+- Refactored duplicated float parsing into the shared `parse_float()` helper.
+- Reused `parse_float()` across climate and sensor entities while preserving existing rounding behavior: climate temperatures remain unrounded, sensor temperatures stay at 1 decimal, and coordinates stay at 6 decimals.
+- Migrated HTTP API tests from `aioresponses` to `aiointercept` so the test stack remains compatible with newer `aiohttp` versions.
+- Kept `pytest-homeassistant-custom-component>=0.13.340` as an open lower bound for test coverage against newer Home Assistant pytest stacks.
+
+### Added
+- Added unit coverage for comma and dot decimal parsing, invalid values, optional precision, `TypeError` handling, and unparseable collections.
+
 ## [0.5.0a1] - 2026-06-24
 
 ### Changed

--- a/custom_components/airzoneclouddaikin/manifest.json
+++ b/custom_components/airzoneclouddaikin/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://github.com/eXPerience83/DKNCloud-HASS",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/eXPerience83/DKNCloud-HASS/issues",
-  "version": "0.5.0a1"
+  "version": "0.5.0a2"
 }


### PR DESCRIPTION
## Summary

Prepares the `0.5.0a2` prerelease after merging #96.

### Changed
- Bumps integration version from `0.5.0a1` to `0.5.0a2`.
- Adds changelog notes for the shared `parse_float()` helper.
- Documents the HTTP test migration from `aioresponses` to `aiointercept`.

### Behavior
No runtime behavior changes are introduced by this release-prep PR. Functional/test changes were already merged in #96.

### Validations
- `ruff check .`
- `black --check .`
- `python -m compileall -q custom_components tests scripts`
- `python -m pytest -q`

### Not changed
- No backend/API changes
- No workflows changes
- No README changes
- No config flow/options/migration changes
- No Device Registry or unique_id changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved number parsing across climate, sensor, and coordinate values for more consistent readings, including better handling of commas, dots, invalid inputs, and precision differences.

* **Tests**
  * Expanded test coverage for decimal parsing edge cases and invalid or unparseable values.
  * Updated the HTTP test approach for better compatibility with the current test stack.

* **Chores**
  * Bumped the integration version to `0.5.0a2` and added a new release entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->