### PR TITLE
Add release workflow concurrency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-${{ github.event.release.tag_name || github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   package-and-upload:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds the release workflow concurrency block used by the Pollen Levels workflow.

### Why

The `v0.5.0a2` release workflow built and validated `airzoneclouddaikin.zip`, but failed during the release asset upload step.

This PR is intentionally conservative: it only aligns the release workflow concurrency behavior with Pollen Levels before making any broader change to the upload step.

### Changed
- Adds `concurrency` to `.github/workflows/release.yml`.

### Not changed
- No `tag_name` added to `softprops/action-gh-release`.
- No integration code changes.
- No tests changes.
- No version bump.
- No changelog changes.
- No package-test workflow changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release handling so published releases run with safer concurrency controls, reducing the chance of overlapping release jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->